### PR TITLE
Last tweaks

### DIFF
--- a/fooof/fit.py
+++ b/fooof/fit.py
@@ -431,8 +431,8 @@ class FOOOF(object):
 
 
     def save(self, save_file='fooof_dat', save_path='', save_results=False,
-             save_settings=False, save_dat=False, append=False,):
-        """Save out data, results and/or settings. Saves out to a JSON file.
+             save_settings=False, save_data=False, append=False):
+        """Save out data, results and/or settings from FOOOF object. Saves out to a JSON file.
 
         Parameters
         ----------
@@ -444,7 +444,7 @@ class FOOOF(object):
             Whether to save out FOOOF model fit results.
         save_settings : bool, optional
             Whether to save out FOOOF settings.
-        save_dat : bool, optional
+        save_data : bool, optional
             Whether to save out input data.
         append : bool, optional
             Whether to append to an existing file, if available. default: False
@@ -460,7 +460,7 @@ class FOOOF(object):
         # Set which variables to keep. Use a set to drop any potential overlap
         keep = set((attributes['results'] if save_results else []) + \
                    (attributes['settings'] if save_settings else []) + \
-                   (attributes['dat'] if save_dat else []))
+                   (attributes['dat'] if save_data else []))
 
         # Keep only requested vars
         obj_dict = dict_select_keys(obj_dict, keep)

--- a/fooof/fit.py
+++ b/fooof/fit.py
@@ -18,7 +18,7 @@ from fooof.funcs import gaussian_function, expo_function, expo_nk_function
 ###################################################################################################
 ###################################################################################################
 
-FOOOFResult = namedtuple('FOOOFResult', ['background_params', 'oscillations_params', 'r2', 'error'])
+FOOOFResult = namedtuple('FOOOFResult', ['background_params', 'oscillation_params', 'r2', 'error'])
 
 class FOOOF(object):
     """Model the physiological power spectrum as oscillatory peaks and 1/f background.

--- a/fooof/fit.py
+++ b/fooof/fit.py
@@ -306,7 +306,7 @@ class FOOOF(object):
         self._rmse_error()
 
 
-    def plot(self, plt_log=False, save_fig=False, save_name='FOOOF_fit.png', save_path='', ax=None):
+    def plot(self, plt_log=False, save_fig=False, save_name='FOOOF_fit', save_path='', ax=None):
         """Plot the original PSD, and full model fit.
 
         Parameters
@@ -323,7 +323,6 @@ class FOOOF(object):
             Figure axes upon which to plot.
         """
 
-        # Throw an error if FOOOF model hasn't been fit yet
         if not np.all(self.freqs):
             raise ValueError('No data available to plot - can not proceed.')
 
@@ -352,7 +351,7 @@ class FOOOF(object):
 
         # Save out figure, if requested
         if save_fig:
-            plt.savefig(os.path.join(save_path, save_name))
+            plt.savefig(os.path.join(save_path, save_name + '.png'))
 
 
     def print_settings(self, description=False):
@@ -504,10 +503,8 @@ class FOOOF(object):
         # Reset data in object, so old data can't interfere
         self._reset_dat()
 
-        # Get dictionary of all attributes that are available for FOOOF
+        # Get dictionary of available attributes, and convert specified lists back into arrays
         attributes = get_attribute_names()
-
-        # Convert specified lists back into arrays
         dat = dict_lst_to_array(dat, attributes['arrays'])
 
         # Reconstruct FOOOF object

--- a/fooof/fit.py
+++ b/fooof/fit.py
@@ -416,7 +416,7 @@ class FOOOF(object):
 
         # Second - data plot
         ax1 = plt.subplot(grid[1])
-        self.plot(ax=ax1)
+        self.plot(plt_log=plt_log, ax=ax1)
 
         # Third - FOOOF settings
         ax2 = plt.subplot(grid[2])

--- a/fooof/fit.py
+++ b/fooof/fit.py
@@ -11,14 +11,16 @@ import matplotlib.pyplot as plt
 from matplotlib import gridspec
 from scipy.optimize import curve_fit
 
-from fooof.utils import group_three, trim_psd, get_attribute_names
+from fooof.utils import trim_psd, mk_freq_vector
+from fooof.utils import group_three, get_attribute_names, check_array_dim
 from fooof.utils import dict_array_to_lst, dict_select_keys, dict_lst_to_array
 from fooof.funcs import gaussian_function, expo_function, expo_nk_function
 
 ###################################################################################################
 ###################################################################################################
 
-FOOOFResult = namedtuple('FOOOFResult', ['background_params', 'oscillation_params', 'r2', 'error'])
+FOOOFResult = namedtuple('FOOOFResult', ['background_params', 'oscillation_params',
+                                         'r2', 'error', 'gaussian_params'])
 
 class FOOOF(object):
     """Model the physiological power spectrum as oscillatory peaks and 1/f background.
@@ -177,6 +179,34 @@ class FOOOF(object):
         self._oscillation_fit = None
 
 
+    @classmethod
+    def from_group(cls, fg, ind, regenerate=False):
+        """Initialize a FOOOF object from specified data in a FOOOFGroup object.
+
+        Parameters
+        ----------
+        fg : FOOOFGroup() object
+            An object with FOOOFResults available.
+        ind : int
+            The index of the FOOOFResult in FOOOFGroup.group_results to load.
+
+        Returns
+        -------
+        inst : FOOOF() object
+            The FOOOFResult data loaded into a FOOOF object.
+        """
+
+        # Initialize instance, inheriting settings from FOOOFGroup object, and copy over frequency information
+        inst = cls(fg.bandwidth_limits, fg.max_n_oscs, fg.min_amp, fg.amp_std_thresh, fg.bg_use_knee, fg.verbose)
+        inst.freq_range, inst.freq_res = fg.freq_range, fg.freq_res
+        inst.freqs = mk_freq_vector(inst.freq_range, inst.freq_res)
+
+        # Add results data from specified FOOOFResult, copy over frequency information, and infer knee
+        inst.add_results(fg.group_results[ind], regenerate=regenerate)
+
+        return inst
+
+
     def add_data(self, freqs, psd, freq_range=None):
         """Add data (frequencies and PSD values) to object.
 
@@ -219,6 +249,27 @@ class FOOOF(object):
 
         # Set the actual frequency range used
         self.freq_range = [self.freqs.min(), self.freqs.max()]
+
+
+    def add_results(self, fooof_result, regenerate=False):
+        """Add results data back into object from a FOOOFResult object.
+
+        Parameters
+        ----------
+        fooof_result : FOOOFResult
+            An object containing the results from fitting a FOOOF model.
+        regenerate : bool, optional
+            Whether to regenerate the model fits from the given fit parameters. default : False
+        """
+
+        self.background_params_ = fooof_result.background_params
+        self.oscillation_params_ = fooof_result.oscillation_params
+        self.r2_ = fooof_result.r2
+        self.error_ = fooof_result.error
+        self._gaussian_params = fooof_result.gaussian_params
+
+        if regenerate:
+            self._regenerate_model()
 
 
     def model(self, freqs=None, psd=None, freq_range=None, plt_log=False):
@@ -380,7 +431,8 @@ class FOOOF(object):
     def get_results(self):
         """Return model fit parameters and error."""
 
-        return FOOOFResult(self.background_params_, self.oscillation_params_, self.r2_, self.error_)
+        return FOOOFResult(self.background_params_, self.oscillation_params_, self.r2_,
+                           self.error_, self._gaussian_params)
 
 
     def create_report(self, save_name='FOOOF_Report', save_path='', plt_log=False):
@@ -511,38 +563,32 @@ class FOOOF(object):
         for key in dat.keys():
             setattr(self, key, dat[key])
 
-        # If settings not loaded from file, clear from object
-        #  So that default settings, which are potentially wrong for loaded data, aren't kept
+        # If settings not loaded from file, clear from object, so that default
+        #  settings, which are potentially wrong for loaded data, aren't kept
         if not set(attributes['settings']).issubset(set(dat.keys())):
-            for setting in attributes['all_settings']:
-                setattr(self, setting, None)
+            self._clear_settings()
 
-            # Infer and set background function, if settings not explicit, but results available
-            #  Given results, can tell which function was used from the length of bg_params
+            # Infer whether knee fitting was used, if background params have been loaded
             if np.all(self.background_params_):
-                if len(self.background_params_) == 3:
-                    self.bg_use_knee = True
-                    self._bg_fit_func = expo_function
-                else:
-                    self.bg_use_knee = False
-                    self._bg_fit_func = expo_nk_function
-                # Also reset oscillation_params, if it happens to be empty, to maintain shape
-                if self.oscillation_params_.ndim == 1:
-                    self.oscillation_params_ = np.empty([0, 3])
+                self._infer_knee()
 
-        # If settings were loaded, reset internal settings so that they are consistent
+        # Otherwise (settings were loaded), reset internal settings so that they are consistent
         else:
             self._reset_settings()
 
-        # Reconstruct frequency vector
+        # If results loaded, check dimensions of osc/gauss parameters
+        #  This fixes an issue where they end up the wrong shape if they are empty (no oscs)
+        if set(attributes['results']).issubset(set(dat.keys())):
+            self.oscillation_params_ = check_array_dim(self.oscillation_params_)
+            self._gaussian_params = check_array_dim(self._gaussian_params)
+
+        # Reconstruct frequency vector, if data available to do so
         if self.freq_res:
-            self.freqs = np.arange(self.freq_range[0], self.freq_range[1]+self.freq_res, self.freq_res)
+            self.freqs = mk_freq_vector(self.freq_range, self.freq_res)
 
         # Recreate PSD model & components
         if np.all(self.freqs) and np.all(self.background_params_):
-            self._background_fit = self._create_bg_fit(self.freqs, self.background_params_)
-            self._oscillation_fit = self._create_osc_fit(self.freqs, self._gaussian_params)
-            self.psd_fit_ = self._oscillation_fit + self._background_fit
+            self._regenerate_model()
 
 
     def _quick_background_fit(self, freqs, psd):
@@ -1008,3 +1054,31 @@ class FOOOF(object):
         ])
 
         return output
+
+
+    def _clear_settings(self):
+        """Clears all setting for current instance, setting them all to None."""
+
+        attributes = get_attribute_names()
+        for setting in attributes['all_settings']:
+            setattr(self, setting, None)
+
+
+    def _infer_knee(self):
+        """Infer from background params, whether knee fitting was used, and update settings."""
+
+        #  Given results, can tell which function was used from the length of bg_params
+        if len(self.background_params_) == 3:
+            self.bg_use_knee = True
+            self._bg_fit_func = expo_function
+        else:
+            self.bg_use_knee = False
+            self._bg_fit_func = expo_nk_function
+
+
+    def _regenerate_model(self):
+        """Regenerate model fit from parameters."""
+
+        self._background_fit = self._create_bg_fit(self.freqs, self.background_params_)
+        self._oscillation_fit = self._create_osc_fit(self.freqs, self._gaussian_params)
+        self.psd_fit_ = self._oscillation_fit + self._background_fit

--- a/fooof/fit.py
+++ b/fooof/fit.py
@@ -248,7 +248,8 @@ class FOOOF(object):
         #   Background fit gets an inf is freq of 0 is included, which leads to an error.
         if self.freqs[0] == 0.0:
             self.freqs, self.psd = trim_psd(freqs, psd, [self.freqs[1], self.freqs.max()])
-            print('\nFOOOF WARNING: Skipping frequency == 0, as this causes problem with fitting.')
+            if self.verbose:
+                print('\nFOOOF WARNING: Skipping frequency == 0, as this causes problem with fitting.')
 
         # Set the actual frequency range used
         self.freq_range = [self.freqs.min(), self.freqs.max()]
@@ -323,9 +324,11 @@ class FOOOF(object):
             raise ValueError('No data available to fit - can not proceed.')
 
         # Check bandwidth limits against frequency resolution; warn if too close.
-        if round(self.freq_res, 1) >= self.bandwidth_limits[0] and self.verbose:
-            print('\nFOOOF WARNING: Lower-bound Bandwidth limit is ~= the frequency resolution. \n',
-                  '  This may lead to overfitting of small bandwidth oscillations.\n')
+        if 1.5 * self.freq_res >= self.bandwidth_limits[0] and self.verbose:
+            print("\nFOOOF WARNING: Lower-bound bandwidth limit is < or ~= the frequency resolution: {:1.2f} <= {:1.2f}\
+                  \n\tLower bounds below frequency-resolution have no effect (effective lower bound is freq-res)\
+                  \n\tToo low a limit may lead to overfitting noise as small bandwidth oscillations.\
+                  \n\tWe recommend a lower bound of approximately 2x the frequency resolution.\n".format(self.freq_res, self.bandwidth_limits[0]))
 
         # Fit the background 1/f.
         self.background_params_ = self._clean_background_fit(self.freqs, self.psd)

--- a/fooof/fit.py
+++ b/fooof/fit.py
@@ -207,7 +207,7 @@ class FOOOF(object):
         return inst
 
 
-    def add_data(self, freqs, psd, freq_range=None):
+    def add_data(self, freqs, psd, freq_range=None, reset_dat=True):
         """Add data (frequencies and PSD values) to object.
 
         Parameters
@@ -218,10 +218,13 @@ class FOOOF(object):
             Power spectral density values, in linear space.
         freq_range : list of [float, float], optional
             Frequency range to restrict PSD to. If not provided, keeps the entire range.
+        reset_dat : bool, optional
+            Whether to clear the object of all prior data before loading. default: True
         """
 
         # Clear any existing data from the object, that could potentially interfere
-        self._reset_dat()
+        if reset_dat:
+            self._reset_dat()
 
         # Check inputs dimensions & size
         if freqs.ndim != psd.ndim != 1:

--- a/fooof/fit.py
+++ b/fooof/fit.py
@@ -384,7 +384,7 @@ class FOOOF(object):
         return FOOOFResult(self.background_params_, self.oscillation_params_, self.r2_, self.error_)
 
 
-    def create_report(self, save_name='FOOOF_Report', save_path=''):
+    def create_report(self, save_name='FOOOF_Report', save_path='', plt_log=False):
         """Generate and save out a report of the current FOOOF fit.
 
         Parameters
@@ -393,6 +393,8 @@ class FOOOF(object):
             Name to give the saved out file.
         save_path : str, optional
             Path to directory in which to save. If not provided, saves to current directory.
+        plt_log : bool, optional
+            Whether or not to plot the frequency axis in log space. default: False
         """
 
         # Set the font description for saving out text with matplotlib

--- a/fooof/fit.py
+++ b/fooof/fit.py
@@ -431,8 +431,8 @@ class FOOOF(object):
         plt.close()
 
 
-    def save(self, save_file='fooof_dat', save_path='',
-             save_results=False, save_settings=False, save_dat=False):
+    def save(self, save_file='fooof_dat', save_path='', save_results=False,
+             save_settings=False, save_dat=False, append=False,):
         """Save out data, results and/or settings. Saves out to a JSON file.
 
         Parameters
@@ -441,12 +441,15 @@ class FOOOF(object):
             File to which to save data.
         save_path : str
             Path to directory to which the save. If not provided, saves to current directory.
-        save_settings : bool, optional
-            Whether to save out FOOOF settings.
         save_results : bool, optional
             Whether to save out FOOOF model fit results.
+        save_settings : bool, optional
+            Whether to save out FOOOF settings.
         save_dat : bool, optional
             Whether to save out input data.
+        append : bool, optional
+            Whether to append to an existing file, if available. default: False
+                This option is only valid (and only used) if save_file is a str.
         """
 
         # Get dictionary of all attributes
@@ -463,11 +466,18 @@ class FOOOF(object):
         # Keep only requested vars
         obj_dict = dict_select_keys(obj_dict, keep)
 
-        # Save out to json
-        if isinstance(save_file, str):
+        # Save out - create new file, (creates a JSON file)
+        if isinstance(save_file, str) and not append:
             with open(os.path.join(save_path, save_file + '.json'), 'w') as outfile:
                 json.dump(obj_dict, outfile)
 
+        # Save out - append to file_name (appends to a JSONlines file)
+        if isinstance(save_file, str) and append:
+            with open(os.path.join(save_path, save_file + '.json'), 'a') as outfile:
+                json.dump(obj_dict, outfile)
+                outfile.write('\n')
+
+        # Save out - append to given file object (appends to a JSONlines file)
         elif isinstance(save_file, io.IOBase):
             json.dump(obj_dict, save_file)
             save_file.write('\n')

--- a/fooof/group.py
+++ b/fooof/group.py
@@ -77,7 +77,7 @@ class FOOOFGroup(FOOOF):
         self._reset_dat(False)
 
 
-    def get_group_results(self):
+    def get_results(self):
         """Return the results run across a group of PSDs."""
 
         return self.group_results
@@ -230,7 +230,7 @@ class FOOOFGroup(FOOOF):
                 # For each line, grab the FOOOFResults
                 try:
                     self._load(f_obj)
-                    self.group_results.append(self.get_results())
+                    self.group_results.append(self._get_results())
 
                 # Break off when get a JSON error - end of the file
                 except JSONDecodeError:
@@ -244,6 +244,12 @@ class FOOOFGroup(FOOOF):
         """Create an alias to FOOOF.fit for FOOOFGroup object, for internal use."""
 
         super().fit(*args, **kwargs)
+
+
+    def _get_results(self):
+        """Create an alias to FOOOF.get_results for FOOOFGroup object, for internal use."""
+
+        return super().get_results()
 
 
     def _save(self, *args, **kwargs):
@@ -386,4 +392,4 @@ def _fit_ret(fg, *args, **kwargs):
     """Helper function for running in parallel."""
 
     fg._fit(*args, **kwargs)
-    return fg.get_results()
+    return fg._get_results()

--- a/fooof/group.py
+++ b/fooof/group.py
@@ -44,13 +44,13 @@ class FOOOFGroup(FOOOF):
             Number of jobs to run in parallel. 1 is no parallelization. -1 indicates to use all cores.
         """
 
-        self.fit(freqs, psds, freq_range)
+        self.fit(freqs, psds, freq_range, n_jobs=n_jobs)
         self.plot()
         self.print_results()
 
 
     def fit(self, freqs, psds, freq_range=None, n_jobs=1):
-        """Run FOOOF across a group of PSDs, optionally saving results as it goes.
+        """Run FOOOF across a group of PSDs.
 
         Parameters
         ----------

--- a/fooof/group.py
+++ b/fooof/group.py
@@ -131,7 +131,7 @@ class FOOOFGroup(FOOOF):
 
 
     def plot(self, save_fig=False, save_name='FOOOF_fit.png', save_path=''):
-        """Plot some data descriptions of the group data.
+        """Plot a multiplot figure of several aspects of the group data.
 
         Parameters
         ----------
@@ -146,25 +146,17 @@ class FOOOFGroup(FOOOF):
         fig = plt.figure(figsize=(14, 10))
         gs = gridspec.GridSpec(2, 2, height_ratios=[1, 1.2])
 
+        # Background parameters plot
         ax0 = plt.subplot(gs[0, 0])
-        #self._plot_bg(ax0)
-        if self.bg_use_knee:
-            self._plot_scatter_2(self.get_all_data('background_params', 1), 'Knee',
-                                 self.get_all_data('background_params', 2), 'Slope',
-                                 'Background Fit', ax=ax0)
-        else:
-            self._plot_scatter_1(self.get_all_data('background_params', 1), 'Slope',
-                                 'Background Fit', ax=ax0)
+        self._plot_bg(ax0)
 
+        # Goodness of fit plot
         ax1 = plt.subplot(gs[0, 1])
-        #self._plot_fit(ax1)
-        self._plot_scatter_2(self.get_all_data('error'), 'Error',
-                             self.get_all_data('r2'), 'R^2', 'Goodness of Fit', ax=ax1)
+        self._plot_gd(ax1)
 
+        # Oscillations plot
         ax2 = plt.subplot(gs[1, :])
-        #self._plot_oscs(ax2)
-        self._plot_hist(self.get_all_data('oscillations_params', 0),
-                        'Center Frequency', 'Oscillations', ax=ax2)
+        self._plot_osc_cens(ax2)
 
         if save_fig:
             plt.savefig(os.path.join(save_path, save_name))
@@ -198,26 +190,17 @@ class FOOOFGroup(FOOOF):
         ax0.set_xticks([])
         ax0.set_yticks([])
 
-        # Add plots (same as from plot())
+        # Background parameters plot
         ax1 = plt.subplot(gs[1, 0])
-        #self._plot_bg(ax1)
-        if self.bg_use_knee:
-            self._plot_scatter_2(self.get_all_data('background_params', 1), 'Knee',
-                                 self.get_all_data('background_params', 2), 'Slope',
-                                 'Background Fit', ax=ax1)
-        else:
-            self._plot_scatter_1(self.get_all_data('background_params', 1), 'Slope',
-                                 'Background Fit', ax=ax1)
+        self._plot_bg(ax1)
 
+        # Goodness of fit plot
         ax2 = plt.subplot(gs[1, 1])
-        #self._plot_fit(ax2)
-        self._plot_scatter_2(self.get_all_data('error'), 'Error',
-                             self.get_all_data('r2'), 'R^2', 'Goodness of Fit', ax=ax2)
+        self._plot_gd(ax2)
 
+        # Oscillations plot
         ax3 = plt.subplot(gs[2, :])
-        #self._plot_oscs(ax3)
-        self._plot_hist(self.get_all_data('oscillations_params', 0),
-                        'Center Frequency', 'Oscillations', ax=ax3)
+        self._plot_osc_cens(ax3)
 
         # Save out the report
         plt.savefig(os.path.join(save_path, save_name + '.pdf'))
@@ -343,6 +326,50 @@ class FOOOFGroup(FOOOF):
         ])
 
         return output
+
+
+    def _plot_bg(self, ax=None):
+        """Plot background fit parameters, in a scatter plot.
+
+        Parameters
+        ----------
+        ax : matplotlib.Axes, optional
+            Figure axes upon which to plot.
+        """
+
+        if self.bg_use_knee:
+            self._plot_scatter_2(self.get_all_data('background_params', 1), 'Knee',
+                                 self.get_all_data('background_params', 2), 'Slope',
+                                 'Background Fit', ax=ax)
+        else:
+            self._plot_scatter_1(self.get_all_data('background_params', 1), 'Slope',
+                                 'Background Fit', ax=ax)
+
+
+    def _plot_gd(self, ax=None):
+        """Plot goodness of fit results, in a scatter plot.
+
+        Parameters
+        ----------
+        ax : matplotlib.Axes, optional
+            Figure axes upon which to plot.
+        """
+
+        self._plot_scatter_2(self.get_all_data('error'), 'Error',
+                             self.get_all_data('r2'), 'R^2', 'Goodness of Fit', ax=ax)
+
+
+    def _plot_osc_cens(self, ax=None):
+        """Plot oscillation center frequencies, in a histogram.
+
+        Parameters
+        ----------
+        ax : matplotlib.Axes, optional
+            Figure axes upon which to plot.
+        """
+
+        self._plot_hist(self.get_all_data('oscillations_params', 0),
+                        'Center Frequency', 'Oscillations', ax=ax)
 
 
     @staticmethod

--- a/fooof/group.py
+++ b/fooof/group.py
@@ -144,7 +144,7 @@ class FOOOFGroup(FOOOF):
         """
 
         fig = plt.figure(figsize=(14, 10))
-        gs = gridspec.GridSpec(2, 2, height_ratios=[1, 1.2])
+        gs = gridspec.GridSpec(2, 2, wspace=0.35, hspace=0.25, height_ratios=[1, 1.2])
 
         # Background parameters plot
         ax0 = plt.subplot(gs[0, 0])
@@ -180,7 +180,7 @@ class FOOOFGroup(FOOOF):
 
         # Initialize figure
         fig = plt.figure(figsize=(16, 20))
-        gs = gridspec.GridSpec(3, 2, height_ratios=[1.5, 1.0, 1.2])
+        gs = gridspec.GridSpec(3, 2, wspace=0.35, hspace=0.25, height_ratios=[1.5, 1.0, 1.2])
 
         # First / top: text results
         ax0 = plt.subplot(gs[0, :])
@@ -398,7 +398,7 @@ class FOOOFGroup(FOOOF):
 
         plt.xticks([0], [label], fontsize=12)
 
-        ax.set_xlim([-0.4, 0.4])
+        ax.set_xlim([-0.5, 0.5])
 
 
     @staticmethod

--- a/fooof/group.py
+++ b/fooof/group.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 from matplotlib import gridspec
 
 from fooof import FOOOF
+from fooof.plts import plot_scatter_1, plot_scatter_2, plot_hist
 
 ###################################################################################################
 ###################################################################################################
@@ -338,11 +339,11 @@ class FOOOFGroup(FOOOF):
         """
 
         if self.bg_use_knee:
-            self._plot_scatter_2(self.get_all_data('background_params', 1), 'Knee',
+            plot_scatter_2(self.get_all_data('background_params', 1), 'Knee',
                                  self.get_all_data('background_params', 2), 'Slope',
                                  'Background Fit', ax=ax)
         else:
-            self._plot_scatter_1(self.get_all_data('background_params', 1), 'Slope',
+            plot_scatter_1(self.get_all_data('background_params', 1), 'Slope',
                                  'Background Fit', ax=ax)
 
 
@@ -355,7 +356,7 @@ class FOOOFGroup(FOOOF):
             Figure axes upon which to plot.
         """
 
-        self._plot_scatter_2(self.get_all_data('error'), 'Error',
+        plot_scatter_2(self.get_all_data('error'), 'Error',
                              self.get_all_data('r2'), 'R^2', 'Goodness of Fit', ax=ax)
 
 
@@ -368,106 +369,8 @@ class FOOOFGroup(FOOOF):
             Figure axes upon which to plot.
         """
 
-        self._plot_hist(self.get_all_data('oscillations_params', 0),
+        plot_hist(self.get_all_data('oscillations_params', 0),
                         'Center Frequency', 'Oscillations', ax=ax)
-
-
-    @staticmethod
-    def _plot_scatter_1(dat, label, title, ax=None):
-        """Plot a scatter plot with the given data.
-
-        Parameters
-        ----------
-        dat : 1d array
-            Data to plot.
-        label : str
-            Label for the data, to be set as the y-axis label.
-        title : str
-            Title for the plot.
-        ax : matplotlib.Axes, optional
-            Figure axes upon which to plot.
-        """
-
-        if not ax:
-            fig, ax = plt.subplots()
-
-        ax.scatter(np.zeros_like(dat) + np.random.normal(0, 0.025, dat.shape), dat, s=36, alpha=0.5)
-        ax.set_ylabel(label, fontsize=12)
-
-        ax.set_title(title, fontsize=16)
-
-        plt.xticks([0], [label], fontsize=12)
-
-        ax.set_xlim([-0.5, 0.5])
-
-
-    @staticmethod
-    def _plot_scatter_2(dat_0, label_0, dat_1, label_1, title, ax=None):
-        """Plot a scatter plot with two y-axes, with the given data.
-
-        Parameters
-        ----------
-        dat_0 : 1d array
-            Data to plot on the first axis.
-        label_0 : str
-            Label for the data on the first axis, to be set as the y-axis label.
-        dat_1 : 1d array
-            Data to plot on the second axis.
-        label_0 : str
-            Label for the data on the second axis, to be set as the y-axis label.
-        title : str
-            Title for the plot.
-        ax : matplotlib.Axes, optional
-            Figure axes upon which to plot.
-        """
-
-        if not ax:
-            fig, ax = plt.subplots()
-
-        ax1 = ax.twinx()
-
-        ax.scatter(np.zeros_like(dat_0) + np.random.normal(0, 0.025, dat_0.shape),
-                   dat_0, s=36, alpha=0.5)
-        ax.set_ylabel(label_0, fontsize=12)
-
-        ax1.scatter(np.ones_like(dat_1) + np.random.normal(0, 0.025, dat_1.shape),
-                    dat_1, s=36, alpha=0.5)
-        ax1.set_ylabel(label_1, fontsize=12)
-
-        ax.set_xlim([-0.5, 1.5])
-
-        ax.set_title(title, fontsize=16)
-
-        plt.xticks([0, 1], [label_0, label_1], fontsize=12)
-
-
-    @staticmethod
-    def _plot_hist(dat, label, title, n_bins=20, ax=None):
-        """Plot a histogram with the given data.
-
-        Parameters
-        ----------
-        dat : 1d array
-            Data to plot.
-        label : str
-            Label for the data, to be set as the y-axis label.
-        title : str
-            Title for the plot.
-        n_bins : int, optional
-            Number of bins to use for the histogram. Default: 20
-        ax : matplotlib.Axes, optional
-            Figure axes upon which to plot.
-        """
-
-        if not ax:
-            fig, ax = plt.subplots()
-
-        ax.hist(dat, n_bins, alpha=0.8)
-
-        ax.set_xlabel(label, fontsize=12)
-        ax.set_ylabel('Count', fontsize=12)
-
-        ax.set_title(title, fontsize=16)
 
 
 FOOOFGroup.__doc__ = FOOOF.__doc__

--- a/fooof/group.py
+++ b/fooof/group.py
@@ -202,8 +202,8 @@ class FOOOFGroup(FOOOF):
         plt.close()
 
 
-    def load_group_results(self, file_name='fooof_group_results', file_path=''):
-        """Load data from file, reconstructing the group_results.
+    def load(self, file_name='fooof_group_results', file_path=''):
+        """Load FOOOFGroup data from file, reconstructing the group_results.
 
         Parameters
         ----------
@@ -223,7 +223,7 @@ class FOOOFGroup(FOOOF):
 
                 # For each line, grab the FOOOFResults
                 try:
-                    self.load(f_obj)
+                    self._load(f_obj)
                     self.group_results.append(self.get_results())
 
                 # Break off when get a JSON error - end of the file
@@ -232,6 +232,18 @@ class FOOOFGroup(FOOOF):
 
         # Reset peripheral data from last loaded result, keeping freqs info
         self._reset_dat(False)
+
+
+    def _load(self, *args, **kwargs):
+        """Rename FOOOF.load for FOOOFGroup object.
+
+        Notes
+        -----
+        - Creates an alias to (with the same API as) FOOOF.load(), for internal use.
+        - This is done for a cleaner API: so that FOOOFGroup.load() loads a group data file.
+        """
+
+        super().load(*args, **kwargs)
 
 
     def _gen_results_str(self):

--- a/fooof/group.py
+++ b/fooof/group.py
@@ -52,7 +52,7 @@ class FOOOFGroup(FOOOF):
         self.print_results()
 
 
-    def fit(self, freqs, psds, freq_range=None, save_dat=False, file_name='fooof_group_results', file_path=''):
+    def fit(self, freqs, psds, freq_range=None, save_dat=False, save_name='fooof_group_results', save_path=''):
         """Run FOOOF across a group of PSDs.
 
         Parameters
@@ -65,9 +65,9 @@ class FOOOFGroup(FOOOF):
             Desired frequency range to run FOOOF on. If not provided, fits the entire given range.
         save_dat : bool, optional
             Whether to save data out to file while running. Default: False.
-        file_name : str, optional
+        save_name : str, optional
             File name to save to.
-        file_path : str, optional
+        save_path : str, optional
             Path to directory in which to save. If not provided, saves to current directory.
         """
 
@@ -76,7 +76,7 @@ class FOOOFGroup(FOOOF):
 
         # If saving, open a file to save to
         if save_dat:
-            f_obj = open(os.path.join(file_path, file_name + '.json'), 'w')
+            f_obj = open(os.path.join(save_path, save_name + '.json'), 'w')
 
         # Fit FOOOF across matrix of PSDs.
         #  Note: shape checking gets performed in fit - wrong shapes/orientations will fail there.
@@ -208,10 +208,22 @@ class FOOOFGroup(FOOOF):
         plt.close()
 
 
-    def save(self):
-        """   """
+    def save(self, save_file='fooof_group_dat', save_path='', save_results=False, save_settings=False):
+        """Save out results and/or settings from FOOOFGroup object. Saves out to a JSON file.
 
-        pass
+        Notes
+        -----
+        - save_data is not availabe with FOOOFGroup, as data are not stored after fitting.
+        """
+
+        if save_results:
+            with open(os.path.join(file_path, file_name + '.json'), 'w') as f_obj:
+                for ind in range(len(self.group_results)):
+                    fm = FOOOF.from_group(fg, ind)
+                    fm.save(save_file=f_obj, save_results=True)
+
+        if save_settings:
+            self._save(save_file=save_file, save_path=save_path, save_settings=True)
 
 
     def load(self, file_name='fooof_group_results', file_path=''):

--- a/fooof/group.py
+++ b/fooof/group.py
@@ -274,7 +274,7 @@ class FOOOFGroup(FOOOF):
         cen_val = 100
 
         # Extract all the relevant data for printing
-        cens = self.get_all_data('oscillations_params', 0)
+        cens = self.get_all_data('oscillation_params', 0)
         r2s = self.get_all_data('r2')
         errors = self.get_all_data('error')
         if self.bg_use_knee:
@@ -375,7 +375,7 @@ class FOOOFGroup(FOOOF):
             Figure axes upon which to plot.
         """
 
-        plot_hist(self.get_all_data('oscillations_params', 0),
+        plot_hist(self.get_all_data('oscillation_params', 0),
                   'Center Frequency', 'Oscillations', ax=ax)
 
 

--- a/fooof/group.py
+++ b/fooof/group.py
@@ -52,7 +52,7 @@ class FOOOFGroup(FOOOF):
         self.print_results()
 
 
-    def fit_group(self, freqs, psds, freq_range=None, save_dat=False, file_name='fooof_group_results', file_path=''):
+    def fit(self, freqs, psds, freq_range=None, save_dat=False, file_name='fooof_group_results', file_path=''):
         """Run FOOOF across a group of PSDs.
 
         Parameters
@@ -81,7 +81,7 @@ class FOOOFGroup(FOOOF):
         # Fit FOOOF across matrix of PSDs.
         #  Note: shape checking gets performed in fit - wrong shapes/orientations will fail there.
         for psd in psds:
-            self.fit(freqs, psd, freq_range)
+            self._fit(freqs, psd, freq_range)
             self.group_results.append(self.get_results())
             if save_dat:
                 self.save(f_obj, save_results=True)
@@ -240,6 +240,18 @@ class FOOOFGroup(FOOOF):
         self._reset_dat(False)
 
 
+    def _fit(self, *args, **kwargs):
+        """Rename FOOOF.fit for FOOOFGroup object.
+
+        Notes
+        -----
+        - Creates an alias to (with the same API as) FOOOF.fit(), for internal use.
+        - This is done for a cleaner API: so that FOOOFGroup.fit() fits a group data file.
+        """
+
+        super().fit(*args, **kwargs)
+
+
     def _load(self, *args, **kwargs):
         """Rename FOOOF.load for FOOOFGroup object.
 
@@ -340,11 +352,11 @@ class FOOOFGroup(FOOOF):
 
         if self.bg_use_knee:
             plot_scatter_2(self.get_all_data('background_params', 1), 'Knee',
-                                 self.get_all_data('background_params', 2), 'Slope',
-                                 'Background Fit', ax=ax)
+                           self.get_all_data('background_params', 2), 'Slope',
+                           'Background Fit', ax=ax)
         else:
             plot_scatter_1(self.get_all_data('background_params', 1), 'Slope',
-                                 'Background Fit', ax=ax)
+                           'Background Fit', ax=ax)
 
 
     def _plot_gd(self, ax=None):
@@ -357,7 +369,7 @@ class FOOOFGroup(FOOOF):
         """
 
         plot_scatter_2(self.get_all_data('error'), 'Error',
-                             self.get_all_data('r2'), 'R^2', 'Goodness of Fit', ax=ax)
+                       self.get_all_data('r2'), 'R^2', 'Goodness of Fit', ax=ax)
 
 
     def _plot_osc_cens(self, ax=None):
@@ -370,7 +382,7 @@ class FOOOFGroup(FOOOF):
         """
 
         plot_hist(self.get_all_data('oscillations_params', 0),
-                        'Center Frequency', 'Oscillations', ax=ax)
+                  'Center Frequency', 'Oscillations', ax=ax)
 
 
 FOOOFGroup.__doc__ = FOOOF.__doc__

--- a/fooof/group.py
+++ b/fooof/group.py
@@ -208,7 +208,7 @@ class FOOOFGroup(FOOOF):
         plt.close()
 
 
-    def save(self, save_file='fooof_group_dat', save_path='', save_results=False, save_settings=False):
+    def save(self, save_file='fooof_group_results', save_path='', save_results=False, save_settings=False):
         """Save out results and/or settings from FOOOFGroup object. Saves out to a JSON file.
 
         Notes
@@ -217,10 +217,10 @@ class FOOOFGroup(FOOOF):
         """
 
         if save_results:
-            with open(os.path.join(file_path, file_name + '.json'), 'w') as f_obj:
+            with open(os.path.join(save_path, save_file + '.json'), 'w') as f_obj:
                 for ind in range(len(self.group_results)):
-                    fm = FOOOF.from_group(fg, ind)
-                    fm.save(save_file=f_obj, save_results=True)
+                    fm = FOOOF.from_group(self, ind, regenerate=False)
+                    fm.save(save_file=f_obj, save_results=True, save_settings=save_settings)
 
         if save_settings:
             self._save(save_file=save_file, save_path=save_path, save_settings=True)

--- a/fooof/group.py
+++ b/fooof/group.py
@@ -47,7 +47,7 @@ class FOOOFGroup(FOOOF):
             Path to directory in which to save. If not provided, saves to current directory.
         """
 
-        self.fit_group(freqs, psds, freq_range, save_dat, file_name, file_path)
+        self.fit(freqs, psds, freq_range, save_dat, file_name, file_path)
         self.plot()
         self.print_results()
 
@@ -241,25 +241,19 @@ class FOOOFGroup(FOOOF):
 
 
     def _fit(self, *args, **kwargs):
-        """Rename FOOOF.fit for FOOOFGroup object.
-
-        Notes
-        -----
-        - Creates an alias to (with the same API as) FOOOF.fit(), for internal use.
-        - This is done for a cleaner API: so that FOOOFGroup.fit() fits a group data file.
-        """
+        """Create an alias to FOOOF.fit for FOOOFGroup object, for internal use."""
 
         super().fit(*args, **kwargs)
 
 
-    def _load(self, *args, **kwargs):
-        """Rename FOOOF.load for FOOOFGroup object.
+    def _save(self, *args, **kwargs):
+        """Create an alias to FOOOF.save for FOOOFGroup object, for internal use."""
 
-        Notes
-        -----
-        - Creates an alias to (with the same API as) FOOOF.load(), for internal use.
-        - This is done for a cleaner API: so that FOOOFGroup.load() loads a group data file.
-        """
+        super().save(*args, **kwargs)
+
+
+    def _load(self, *args, **kwargs):
+        """Create an alias to FOOOF.load for FOOOFGroup object, for internal use."""
 
         super().load(*args, **kwargs)
 

--- a/fooof/group.py
+++ b/fooof/group.py
@@ -6,8 +6,6 @@ from json import JSONDecodeError
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import gridspec
-#from sklearn.externals.joblib import Parallel, delayed
-
 from functools import partial
 from multiprocessing import Pool, cpu_count
 
@@ -73,7 +71,6 @@ class FOOOFGroup(FOOOF):
             Number of jobs to run in parallel. 1 is no parallelization. -1 indicates to use all cores.
         """
 
-        # NEW:
         # Run linearly
         if n_jobs == 1:
             self._reset_group_results(len(psds))
@@ -91,19 +88,6 @@ class FOOOFGroup(FOOOF):
             pool.close()
 
         self._reset_dat(clear_freqs=False)
-
-        # OLD:
-        # # Clear results so that any prior data doesn't end up lumped together
-        # self._reset_group_results()
-
-        # # Add data (to set frequency information in object), then run FOOOF across the group.
-        # self.add_data(freqs, psds[0], freq_range)
-        # self.group_results = Parallel(n_jobs=n_jobs)(delayed(_fit_ret)(self, freqs, psd, freq_range) \
-        #         for psd in psds)
-
-        # # Clear out last run PSD, but while keeping frequency information
-        # #  This is so that it doesn't retain data from an arbitrary PSD
-        # self._reset_dat(False)
 
 
     def get_results(self):
@@ -415,13 +399,6 @@ class FOOOFGroup(FOOOF):
 
 
 FOOOFGroup.__doc__ = FOOOF.__doc__
-
-
-def _fit_ret(fg, *args, **kwargs):
-    """Helper function for running in parallel."""
-
-    fg._fit(*args, **kwargs)
-    return fg._get_results()
 
 
 def _par_fit(psd, fg, freqs, freq_range):

--- a/fooof/group.py
+++ b/fooof/group.py
@@ -84,7 +84,7 @@ class FOOOFGroup(FOOOF):
             self._fit(freqs, psd, freq_range)
             self.group_results.append(self.get_results())
             if save_dat:
-                self.save(f_obj, save_results=True)
+                self._save(f_obj, save_results=True)
 
         # Clear out last run PSD, but while keeping frequency information
         #  This is so that it doesn't retain data from an arbitrary PSD
@@ -131,7 +131,7 @@ class FOOOFGroup(FOOOF):
         return out
 
 
-    def plot(self, save_fig=False, save_name='FOOOF_fit.png', save_path=''):
+    def plot(self, save_fig=False, save_name='FOOOF_fit', save_path=''):
         """Plot a multiplot figure of several aspects of the group data.
 
         Parameters
@@ -160,7 +160,7 @@ class FOOOFGroup(FOOOF):
         self._plot_osc_cens(ax2)
 
         if save_fig:
-            plt.savefig(os.path.join(save_path, save_name))
+            plt.savefig(os.path.join(save_path, save_name + '.png'))
 
 
     def create_report(self, save_name='FOOOFGroup_Report', save_path=''):
@@ -206,6 +206,12 @@ class FOOOFGroup(FOOOF):
         # Save out the report
         plt.savefig(os.path.join(save_path, save_name + '.pdf'))
         plt.close()
+
+
+    def save(self):
+        """   """
+
+        pass
 
 
     def load(self, file_name='fooof_group_results', file_path=''):

--- a/fooof/plts.py
+++ b/fooof/plts.py
@@ -18,7 +18,7 @@ def plot_scatter_1(dat, label, title=None, x_val=0, ax=None):
     title : str, optional
         Title for the plot.
     x_val : int, optional
-    	Position along the x-axis to plot set of data. default: 0
+        Position along the x-axis to plot set of data. default: 0
     ax : matplotlib.Axes, optional
         Figure axes upon which to plot.
 
@@ -33,10 +33,10 @@ def plot_scatter_1(dat, label, title=None, x_val=0, ax=None):
     ax.scatter(np.ones_like(dat) * x_val + np.random.normal(0, 0.025, dat.shape), dat, s=36, alpha=0.5)
 
     if label:
-	    ax.set_ylabel(label, fontsize=12)
+        ax.set_ylabel(label, fontsize=12)
 
     if title:
-	    ax.set_title(title, fontsize=16)
+        ax.set_title(title, fontsize=16)
 
     plt.xticks([x_val], [label], fontsize=12)
 
@@ -75,7 +75,7 @@ def plot_scatter_2(dat_0, label_0, dat_1, label_1, title=None, ax=None):
     plot_scatter_1(dat_1, label_1, x_val=1, ax=ax1)
 
     if title:
-	    ax.set_title(title, fontsize=16)
+        ax.set_title(title, fontsize=16)
 
     ax.set_xlim([-0.5, 1.5])
     plt.xticks([0, 1], [label_0, label_1], fontsize=12)

--- a/fooof/plts.py
+++ b/fooof/plts.py
@@ -1,4 +1,4 @@
-"""Plot templates for FOOOF."""
+"""Plot templates for FOOOF data."""
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 ###################################################################################################
 ###################################################################################################
 
-def plot_scatter_1(dat, label=None, title=None, x_val=0, ax=None):
+def plot_scatter_1(dat, label, title=None, x_val=0, ax=None):
     """Plot a scatter plot with the given data.
 
     Parameters
@@ -15,8 +15,10 @@ def plot_scatter_1(dat, label=None, title=None, x_val=0, ax=None):
         Data to plot.
     label : str
         Label for the data, to be set as the y-axis label.
-    title : str
+    title : str, optional
         Title for the plot.
+    x_val : int, optional
+    	Position along the x-axis to plot set of data. default: 0
     ax : matplotlib.Axes, optional
         Figure axes upon which to plot.
 

--- a/fooof/plts.py
+++ b/fooof/plts.py
@@ -1,0 +1,109 @@
+"""Plot templates for FOOOF."""
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+###################################################################################################
+###################################################################################################
+
+def plot_scatter_1(dat, label, title, ax=None):
+    """Plot a scatter plot with the given data.
+
+    Parameters
+    ----------
+    dat : 1d array
+        Data to plot.
+    label : str
+        Label for the data, to be set as the y-axis label.
+    title : str
+        Title for the plot.
+    ax : matplotlib.Axes, optional
+        Figure axes upon which to plot.
+
+    Notes
+    -----
+    Data is jittered slightly, for visualization purposes (deviations on x-axis are meaningless).
+    """
+
+    if not ax:
+        fig, ax = plt.subplots()
+
+    ax.scatter(np.zeros_like(dat) + np.random.normal(0, 0.025, dat.shape), dat, s=36, alpha=0.5)
+    ax.set_ylabel(label, fontsize=12)
+
+    ax.set_title(title, fontsize=16)
+
+    plt.xticks([0], [label], fontsize=12)
+
+    ax.set_xlim([-0.5, 0.5])
+
+
+def plot_scatter_2(dat_0, label_0, dat_1, label_1, title, ax=None):
+    """Plot a scatter plot with two y-axes, with the given data.
+
+    Parameters
+    ----------
+    dat_0 : 1d array
+        Data to plot on the first axis.
+    label_0 : str
+        Label for the data on the first axis, to be set as the y-axis label.
+    dat_1 : 1d array
+        Data to plot on the second axis.
+    label_0 : str
+        Label for the data on the second axis, to be set as the y-axis label.
+    title : str
+        Title for the plot.
+    ax : matplotlib.Axes, optional
+        Figure axes upon which to plot.
+
+    Notes
+    -----
+    Data is jittered slightly, for visualization purposes (deviations on x-axis are meaningless).
+    """
+
+    if not ax:
+        fig, ax = plt.subplots()
+
+    ax1 = ax.twinx()
+
+    ax.scatter(np.zeros_like(dat_0) + np.random.normal(0, 0.025, dat_0.shape),
+               dat_0, s=36, alpha=0.5)
+    ax.set_ylabel(label_0, fontsize=12)
+
+    ax1.scatter(np.ones_like(dat_1) + np.random.normal(0, 0.025, dat_1.shape),
+                dat_1, s=36, alpha=0.5)
+    ax1.set_ylabel(label_1, fontsize=12)
+
+    ax.set_xlim([-0.5, 1.5])
+
+    ax.set_title(title, fontsize=16)
+
+    plt.xticks([0, 1], [label_0, label_1], fontsize=12)
+
+
+def plot_hist(dat, label, title, n_bins=20, ax=None):
+    """Plot a histogram with the given data.
+
+    Parameters
+    ----------
+    dat : 1d array
+        Data to plot.
+    label : str
+        Label for the data, to be set as the y-axis label.
+    title : str
+        Title for the plot.
+    n_bins : int, optional
+        Number of bins to use for the histogram. Default: 20
+    ax : matplotlib.Axes, optional
+        Figure axes upon which to plot.
+    """
+
+    if not ax:
+        fig, ax = plt.subplots()
+
+    ax.hist(dat, n_bins, alpha=0.8)
+
+    ax.set_xlabel(label, fontsize=12)
+    ax.set_ylabel('Count', fontsize=12)
+
+    ax.set_title(title, fontsize=16)

--- a/fooof/plts.py
+++ b/fooof/plts.py
@@ -81,7 +81,7 @@ def plot_scatter_2(dat_0, label_0, dat_1, label_1, title=None, ax=None):
     plt.xticks([0, 1], [label_0, label_1], fontsize=12)
 
 
-def plot_hist(dat, label, title, n_bins=20, ax=None):
+def plot_hist(dat, label, title=None, n_bins=20, ax=None):
     """Plot a histogram with the given data.
 
     Parameters
@@ -90,7 +90,7 @@ def plot_hist(dat, label, title, n_bins=20, ax=None):
         Data to plot.
     label : str
         Label for the data, to be set as the y-axis label.
-    title : str
+    title : str, optional
         Title for the plot.
     n_bins : int, optional
         Number of bins to use for the histogram. Default: 20
@@ -106,4 +106,5 @@ def plot_hist(dat, label, title, n_bins=20, ax=None):
     ax.set_xlabel(label, fontsize=12)
     ax.set_ylabel('Count', fontsize=12)
 
-    ax.set_title(title, fontsize=16)
+    if title:
+        ax.set_title(title, fontsize=16)

--- a/fooof/plts.py
+++ b/fooof/plts.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 ###################################################################################################
 ###################################################################################################
 
-def plot_scatter_1(dat, label, title, ax=None):
+def plot_scatter_1(dat, label=None, title=None, x_val=0, ax=None):
     """Plot a scatter plot with the given data.
 
     Parameters
@@ -28,17 +28,20 @@ def plot_scatter_1(dat, label, title, ax=None):
     if not ax:
         fig, ax = plt.subplots()
 
-    ax.scatter(np.zeros_like(dat) + np.random.normal(0, 0.025, dat.shape), dat, s=36, alpha=0.5)
-    ax.set_ylabel(label, fontsize=12)
+    ax.scatter(np.ones_like(dat) * x_val + np.random.normal(0, 0.025, dat.shape), dat, s=36, alpha=0.5)
 
-    ax.set_title(title, fontsize=16)
+    if label:
+	    ax.set_ylabel(label, fontsize=12)
 
-    plt.xticks([0], [label], fontsize=12)
+    if title:
+	    ax.set_title(title, fontsize=16)
+
+    plt.xticks([x_val], [label], fontsize=12)
 
     ax.set_xlim([-0.5, 0.5])
 
 
-def plot_scatter_2(dat_0, label_0, dat_1, label_1, title, ax=None):
+def plot_scatter_2(dat_0, label_0, dat_1, label_1, title=None, ax=None):
     """Plot a scatter plot with two y-axes, with the given data.
 
     Parameters
@@ -66,18 +69,13 @@ def plot_scatter_2(dat_0, label_0, dat_1, label_1, title, ax=None):
 
     ax1 = ax.twinx()
 
-    ax.scatter(np.zeros_like(dat_0) + np.random.normal(0, 0.025, dat_0.shape),
-               dat_0, s=36, alpha=0.5)
-    ax.set_ylabel(label_0, fontsize=12)
+    plot_scatter_1(dat_0, label_0, ax=ax)
+    plot_scatter_1(dat_1, label_1, x_val=1, ax=ax1)
 
-    ax1.scatter(np.ones_like(dat_1) + np.random.normal(0, 0.025, dat_1.shape),
-                dat_1, s=36, alpha=0.5)
-    ax1.set_ylabel(label_1, fontsize=12)
+    if title:
+	    ax.set_title(title, fontsize=16)
 
     ax.set_xlim([-0.5, 1.5])
-
-    ax.set_title(title, fontsize=16)
-
     plt.xticks([0, 1], [label_0, label_1], fontsize=12)
 
 

--- a/fooof/synth.py
+++ b/fooof/synth.py
@@ -1,4 +1,4 @@
-"""Util functions for FOOOF tests."""
+"""Creating synthetic PSDs for using with, and testing, FOOOF."""
 
 import numpy as np
 
@@ -38,6 +38,7 @@ def mk_fake_data(xs, bgp, oscs, knee=False, nlv=0.005):
 	ys = np.power(10, bg + oscs + noise)
 
 	return xs, ys
+
 
 def mk_fake_group_data(xs, n_psds=5):
 	"""Create a matrix of fake PSDs for testing.

--- a/fooof/synth.py
+++ b/fooof/synth.py
@@ -8,63 +8,63 @@ from fooof.funcs import gaussian_function, expo_function, expo_nk_function
 ##########################################################################################
 
 def mk_fake_data(xs, bgp, oscs, knee=False, nlv=0.005):
-	"""Create fake PSD for testing.
+    """Create fake PSD for testing.
 
-	Parameters
-	----------
-	xs : 1d array
-		Frequency vector to create fake PSD with.
-	bgp : list of [float, float, float]
-		Parameters to create the background of PSD.
-	oscs : list of [float, float, float]
-		Parameters to create oscillations. Length of n_oscs * 3.
-	knee : bool, optional
-		Whether to generate PSD with a knee of not. Default: False
-	nlv : float, optional
-		Noise level to add to generated PSD. Default: 0.005
+    Parameters
+    ----------
+    xs : 1d array
+        Frequency vector to create fake PSD with.
+    bgp : list of [float, float, float]
+        Parameters to create the background of PSD.
+    oscs : list of [float, float, float]
+        Parameters to create oscillations. Length of n_oscs * 3.
+    knee : bool, optional
+        Whether to generate PSD with a knee of not. Default: False
+    nlv : float, optional
+        Noise level to add to generated PSD. Default: 0.005
 
-	Returns
-	-------
-	xs : 1d array
-		Frequency values (linear).
-	ys : 1d array
-		Power values (linear).
-	"""
+    Returns
+    -------
+    xs : 1d array
+        Frequency values (linear).
+    ys : 1d array
+        Power values (linear).
+    """
 
-	bg = expo_function(xs, *bgp) if knee else expo_nk_function(xs, *bgp)
-	oscs = gaussian_function(xs, *oscs)
-	noise = np.random.normal(0, nlv, len(xs))
+    bg = expo_function(xs, *bgp) if knee else expo_nk_function(xs, *bgp)
+    oscs = gaussian_function(xs, *oscs)
+    noise = np.random.normal(0, nlv, len(xs))
 
-	ys = np.power(10, bg + oscs + noise)
+    ys = np.power(10, bg + oscs + noise)
 
-	return xs, ys
+    return xs, ys
 
 
 def mk_fake_group_data(xs, n_psds=5):
-	"""Create a matrix of fake PSDs for testing.
+    """Create a matrix of fake PSDs for testing.
 
-	Parameters
-	----------
-	xs : 1d array
-		Frequency vector to create fake PSDs with.
-	n_psds : int, optional
-		The number of PSDs to generate in the matrix.
+    Parameters
+    ----------
+    xs : 1d array
+        Frequency vector to create fake PSDs with.
+    n_psds : int, optional
+        The number of PSDs to generate in the matrix.
 
-	Returns
-	-------
-	xs : 1d array
-		Frequency values (linear).
-	ys : 2d array
-		Matrix of power values (linear).
-	"""
+    Returns
+    -------
+    xs : 1d array
+        Frequency values (linear).
+    ys : 2d array
+        Matrix of power values (linear).
+    """
 
-	ys = np.zeros([n_psds, len(xs)])
+    ys = np.zeros([n_psds, len(xs)])
 
-	bgp_opts = [[20, 2], [50, 2.5], [35, 1.5]]
-	osc_opts = [[], [10, 0.5, 2], [10, 0.5, 2, 20, 0.3, 4]]
+    bgp_opts = [[20, 2], [50, 2.5], [35, 1.5]]
+    osc_opts = [[], [10, 0.5, 2], [10, 0.5, 2, 20, 0.3, 4]]
 
-	for i in range(n_psds):
-		_, ys[i, :] = mk_fake_data(xs, bgp_opts[np.random.randint(0, len(bgp_opts))],
-								   osc_opts[np.random.randint(0, len(osc_opts))])
+    for i in range(n_psds):
+        _, ys[i, :] = mk_fake_data(xs, bgp_opts[np.random.randint(0, len(bgp_opts))],
+                                   osc_opts[np.random.randint(0, len(osc_opts))])
 
-	return xs, ys
+    return xs, ys

--- a/fooof/tests/conftest.py
+++ b/fooof/tests/conftest.py
@@ -11,7 +11,7 @@ import pytest
 
 @pytest.fixture(scope='session', autouse=True)
 def check_dir():
-	"""Once, prior to session, this will clear and re-initialize the test file directories."""
+    """Once, prior to session, this will clear and re-initialize the test file directories."""
 
     rep_dir_name = pkg.resource_filename(__name__, 'test_reports')
     dat_dir_name = pkg.resource_filename(__name__, 'test_files')

--- a/fooof/tests/conftest.py
+++ b/fooof/tests/conftest.py
@@ -1,0 +1,27 @@
+"""Configuration file for pytest."""
+
+import os
+import shutil
+import pkg_resources as pkg
+
+import pytest
+
+###################################################################################################
+###################################################################################################
+
+@pytest.fixture(scope='session', autouse=True)
+def check_dir():
+	"""Once, prior to session, this will clear and re-initialize the test file directories."""
+
+    rep_dir_name = pkg.resource_filename(__name__, 'test_reports')
+    dat_dir_name = pkg.resource_filename(__name__, 'test_files')
+
+    # If the directories already exist, clear them
+    if os.path.exists(rep_dir_name):
+        shutil.rmtree(rep_dir_name)
+    if os.path.exists(dat_dir_name):
+        shutil.rmtree(dat_dir_name)
+
+    # Remake (empty) directories
+    os.mkdir(rep_dir_name)
+    os.mkdir(dat_dir_name)

--- a/fooof/tests/test_fit.py
+++ b/fooof/tests/test_fit.py
@@ -13,7 +13,7 @@ import numpy as np
 import pkg_resources as pkg
 
 from fooof import FOOOF
-from fooof.tests.utils import mk_fake_data
+from fooof.synth import mk_fake_data
 
 ##########################################################################################
 ##########################################################################################

--- a/fooof/tests/test_fit.py
+++ b/fooof/tests/test_fit.py
@@ -14,6 +14,7 @@ import pkg_resources as pkg
 
 from fooof import FOOOF
 from fooof.synth import mk_fake_data
+from fooof.utils import mk_freq_vector
 
 ##########################################################################################
 ##########################################################################################
@@ -26,7 +27,7 @@ def test_fooof():
 def test_fooof_fit_nk():
 	"""Test FOOOF fit, no knee."""
 
-	xs = np.arange(3, 50, 0.5)
+	xs = mk_freq_vector([3, 50], 0.5)
 	bgp = [50, 2]
 	oscs = [[10, 0.5, 2],
 			[20, 0.3, 4]]
@@ -46,7 +47,7 @@ def test_fooof_fit_nk():
 def test_fooof_checks():
 	"""Test various checks, errors and edge cases in FOOOF."""
 
-	xs, ys = mk_fake_data(np.arange(3, 50, 0.5), [50, 2], [10, 0.5, 2])
+	xs, ys = mk_fake_data(mk_freq_vector([3, 50], 0.5), [50, 2], [10, 0.5, 2])
 
 	fm = FOOOF()
 
@@ -62,7 +63,7 @@ def test_fooof_checks():
 	fm.fit(xs, ys, [3, 40])
 
 	# Check freq of 0 issue
-	xs, ys = mk_fake_data(np.arange(0, 50, 0.5), [50, 2], [10, 0.5, 2])
+	xs, ys = mk_fake_data(mk_freq_vector([3, 50], 0.5), [50, 2], [10, 0.5, 2])
 	fm.fit(xs, ys)
 
 	# Check fit, plot and string report model error (no data / model fit)
@@ -82,7 +83,7 @@ def test_fooof_prints_plot_get_report():
 	Note: minimal test - that methods run. No accuracy checking.
 	"""
 
-	xs, ys = mk_fake_data(np.arange(3, 50, 0.5), [50, 2], [10, 0.5, 2, 20, 0.3, 4])
+	xs, ys = mk_fake_data(mk_freq_vector([3, 50], 0.5), [50, 2], [10, 0.5, 2, 20, 0.3, 4])
 
 	fm = FOOOF()
 
@@ -107,7 +108,7 @@ def test_fooof_prints_plot_get_report():
 def test_fooof_save_load_str():
 	"""Check that FOOOF object saves & loads - given str input."""
 
-	xs, ys = mk_fake_data(np.arange(3, 50, 0.5), [50, 2], [10, 0.5, 2, 20, 0.3, 4])
+	xs, ys = mk_fake_data(mk_freq_vector([3, 50], 0.5), [50, 2], [10, 0.5, 2, 20, 0.3, 4])
 
 	fm = FOOOF()
 	fm.fit(xs, ys)
@@ -127,7 +128,7 @@ def test_fooof_save_load_str():
 def test_fooof_save_load_file_obj():
 	"""Check that FOOOF object saves & loads - given file obj input."""
 
-	xs, ys = mk_fake_data(np.arange(3, 50, 0.5), [50, 2], [10, 0.5, 2, 20, 0.3, 4])
+	xs, ys = mk_fake_data(mk_freq_vector([3, 50], 0.5), [50, 2], [10, 0.5, 2, 20, 0.3, 4])
 
 	fm = FOOOF()
 	fm.fit(xs, ys)
@@ -158,7 +159,7 @@ def test_fooof_reset_dat():
 
 	fm = FOOOF()
 
-	fm.fit(*mk_fake_data(np.arange(3, 50, 0.5), [50, 2], [10, 0.5, 2, 20, 0.3, 4]))
+	fm.fit(*mk_fake_data(mk_freq_vector([3, 50], 0.5), [50, 2], [10, 0.5, 2, 20, 0.3, 4]))
 	fm._reset_dat()
 
 	assert fm.freqs is None and fm.psd is None and fm.freq_range is None \
@@ -172,6 +173,6 @@ def test_fooof_model():
 
 	fm = FOOOF()
 
-	fm.model(*mk_fake_data(np.arange(3, 50, 0.5), [50, 2], [10, 0.5, 2, 20, 0.3, 4]))
+	fm.model(*mk_fake_data(mk_freq_vector([3, 50], 0.5), [50, 2], [10, 0.5, 2, 20, 0.3, 4]))
 
 	assert fm

--- a/fooof/tests/test_fit.py
+++ b/fooof/tests/test_fit.py
@@ -158,7 +158,7 @@ def test_fooof_reset_dat():
 
 	fm = FOOOF()
 
-	fm.model(*mk_fake_data(np.arange(3, 50, 0.5), [50, 2], [10, 0.5, 2, 20, 0.3, 4]))
+	fm.fit(*mk_fake_data(np.arange(3, 50, 0.5), [50, 2], [10, 0.5, 2, 20, 0.3, 4]))
 	fm._reset_dat()
 
 	assert fm.freqs is None and fm.psd is None and fm.freq_range is None \
@@ -166,3 +166,12 @@ def test_fooof_reset_dat():
 		and fm.oscillation_params_ is None and fm.r2_ is None and fm.error_ is None \
 		and fm._psd_flat is None and fm._psd_osc_rm is None and fm._gaussian_params is None \
 		and fm._background_fit is None and fm._oscillation_fit is None
+
+def test_fooof_model():
+	"""Check that running the top level model method runs."""
+
+	fm = FOOOF()
+
+	fm.model(*mk_fake_data(np.arange(3, 50, 0.5), [50, 2], [10, 0.5, 2, 20, 0.3, 4]))
+
+	assert fm

--- a/fooof/tests/test_group.py
+++ b/fooof/tests/test_group.py
@@ -29,7 +29,7 @@ def test_fooof_group_fit():
 
 	fg = FOOOFGroup()
 
-	fg.fit_group(xs, ys)
+	fg.fit(xs, ys)
 
 	out = fg.get_group_results()
 
@@ -45,7 +45,7 @@ def test_fooof_group_fit_save_load():
 
 	fg = FOOOFGroup()
 
-	fg.fit_group(xs, ys, save_dat=True, file_name=file_name, file_path=file_path)
+	fg.fit(xs, ys, save_dat=True, file_name=file_name, file_path=file_path)
 
 	assert os.path.exists(os.path.join(file_path, file_name + '.json'))
 
@@ -63,7 +63,7 @@ def test_fooof_group_plot_get_report():
 
 	fg = FOOOFGroup()
 
-	fg.fit_group(xs, ys)
+	fg.fit(xs, ys)
 
 	fg.print_results()
 

--- a/fooof/tests/test_group.py
+++ b/fooof/tests/test_group.py
@@ -50,7 +50,7 @@ def test_fooof_group_fit_save_load():
 	assert os.path.exists(os.path.join(file_path, file_name + '.json'))
 
 	nfg = FOOOFGroup()
-	nfg.load_group_results(file_name=file_name, file_path=file_path)
+	nfg.load(file_name=file_name, file_path=file_path)
 
 	out = nfg.get_group_results()
 

--- a/fooof/tests/test_group.py
+++ b/fooof/tests/test_group.py
@@ -45,7 +45,7 @@ def test_fooof_group_fit_save_load():
 
 	fg = FOOOFGroup()
 
-	fg.fit(xs, ys, save_dat=True, file_name=file_name, file_path=file_path)
+	fg.fit(xs, ys, save_dat=True, save_name=file_name, save_path=file_path)
 
 	assert os.path.exists(os.path.join(file_path, file_name + '.json'))
 

--- a/fooof/tests/test_group.py
+++ b/fooof/tests/test_group.py
@@ -32,7 +32,7 @@ def test_fooof_group_fit():
 
 	fg.fit(xs, ys)
 
-	out = fg.get_group_results()
+	out = fg.get_results()
 
 	assert out
 
@@ -45,7 +45,7 @@ def test_fooof_group_fit_par():
 
 	fg.fit(xs, ys, n_jobs=-1)
 
-	out = fg.get_group_results()
+	out = fg.get_results()
 
 	assert out
 
@@ -73,7 +73,7 @@ def test_fooof_group_save_load():
 	assert nfg.min_amp == 0.01
 
 	nfg.load(file_name=res_file_name, file_path=file_path)
-	assert nfg.get_group_results()
+	assert nfg.get_results()
 
 def test_fooof_group_plot_get_report():
 	"""Check methods that print, plot, and create report."""

--- a/fooof/tests/test_group.py
+++ b/fooof/tests/test_group.py
@@ -35,8 +35,8 @@ def test_fooof_group_fit():
 
 	assert out
 
-def test_fooof_group_fit_save_load():
-	"""Check that FOOOFGroup saves and loads."""
+def test_fooof_group_save_asyougo_load():
+	"""Check that FOOOFGroup saves (as-you-go) and loads."""
 
 	xs, ys = mk_fake_group_data(np.arange(3, 50, 0.5))
 
@@ -55,6 +55,32 @@ def test_fooof_group_fit_save_load():
 	out = nfg.get_group_results()
 
 	assert out
+
+def test_fooof_group_save_after_load():
+	"""Test that FOOOFGroup saves (after-running) and loads, including settings & results."""
+
+	xs, ys = mk_fake_group_data(np.arange(3, 50, 0.5))
+
+	set_file_name = 'test_fooof_group_set'
+	res_file_name = 'test_fooof_group_res'
+	file_path = pkg.resource_filename(__name__, 'test_files')
+
+	fg = FOOOFGroup(min_amp=0.01)
+
+	fg.fit(xs, ys)
+	fg.save(save_file=set_file_name, save_path=file_path, save_settings=True)
+	fg.save(save_file=res_file_name, save_path=file_path, save_results=True)
+
+	assert os.path.exists(os.path.join(file_path, set_file_name + '.json'))
+	assert os.path.exists(os.path.join(file_path, res_file_name + '.json'))
+
+	nfg = FOOOFGroup()
+
+	nfg.load(file_name=set_file_name, file_path=file_path)
+	assert nfg.min_amp == 0.01
+
+	nfg.load(file_name=res_file_name, file_path=file_path)
+	assert nfg.get_group_results()
 
 def test_fooof_group_plot_get_report():
 	"""Check methods that print, plot, and create report."""

--- a/fooof/tests/test_group.py
+++ b/fooof/tests/test_group.py
@@ -13,6 +13,7 @@ import numpy as np
 
 from fooof import FOOOFGroup
 from fooof.synth import mk_fake_group_data
+from fooof.utils import mk_freq_vector
 
 ##########################################################################################
 ##########################################################################################
@@ -25,7 +26,7 @@ def test_fooof_group():
 def test_fooof_group_fit():
 	"""Test FOOOFGroup fit, no knee."""
 
-	xs, ys = mk_fake_group_data(np.arange(3, 50, 0.5))
+	xs, ys = mk_fake_group_data(mk_freq_vector([3, 50], 0.5))
 
 	fg = FOOOFGroup()
 
@@ -38,7 +39,7 @@ def test_fooof_group_fit():
 def test_fooof_group_fit_par():
 	"""Test FOOOFGroup fit, running in parallel."""
 
-	xs, ys = mk_fake_group_data(np.arange(3, 50, 0.5))
+	xs, ys = mk_fake_group_data(mk_freq_vector([3, 50], 0.5))
 
 	fg = FOOOFGroup()
 
@@ -51,7 +52,7 @@ def test_fooof_group_fit_par():
 def test_fooof_group_save_load():
 	"""Test that FOOOFGroup saves and loads, including settings & results."""
 
-	xs, ys = mk_fake_group_data(np.arange(3, 50, 0.5))
+	xs, ys = mk_fake_group_data(mk_freq_vector([3, 50], 0.5))
 
 	set_file_name = 'test_fooof_group_set'
 	res_file_name = 'test_fooof_group_res'
@@ -77,7 +78,7 @@ def test_fooof_group_save_load():
 def test_fooof_group_plot_get_report():
 	"""Check methods that print, plot, and create report."""
 
-	xs, ys = mk_fake_group_data(np.arange(3, 50, 0.5))
+	xs, ys = mk_fake_group_data(mk_freq_vector([3, 50], 0.5))
 
 	fg = FOOOFGroup()
 
@@ -97,7 +98,7 @@ def test_fooof_group_plot_get_report():
 def test_fooof_group_model():
 	"""Check that running the top level model method runs."""
 
-	xs, ys = mk_fake_group_data(np.arange(3, 50, 0.5))
+	xs, ys = mk_fake_group_data(mk_freq_vector([3, 50], 0.5))
 
 	fg = FOOOFGroup()
 

--- a/fooof/tests/test_group.py
+++ b/fooof/tests/test_group.py
@@ -35,29 +35,21 @@ def test_fooof_group_fit():
 
 	assert out
 
-def test_fooof_group_save_asyougo_load():
-	"""Check that FOOOFGroup saves (as-you-go) and loads."""
+def test_fooof_group_fit_par():
+	"""Test FOOOFGroup fit, running in parallel."""
 
 	xs, ys = mk_fake_group_data(np.arange(3, 50, 0.5))
 
-	file_name = 'test_fooof_group'
-	file_path = pkg.resource_filename(__name__, 'test_files')
-
 	fg = FOOOFGroup()
 
-	fg.fit(xs, ys, save_dat=True, save_name=file_name, save_path=file_path)
+	fg.fit(xs, ys, n_jobs=-1)
 
-	assert os.path.exists(os.path.join(file_path, file_name + '.json'))
-
-	nfg = FOOOFGroup()
-	nfg.load(file_name=file_name, file_path=file_path)
-
-	out = nfg.get_group_results()
+	out = fg.get_group_results()
 
 	assert out
 
-def test_fooof_group_save_after_load():
-	"""Test that FOOOFGroup saves (after-running) and loads, including settings & results."""
+def test_fooof_group_save_load():
+	"""Test that FOOOFGroup saves and loads, including settings & results."""
 
 	xs, ys = mk_fake_group_data(np.arange(3, 50, 0.5))
 

--- a/fooof/tests/test_group.py
+++ b/fooof/tests/test_group.py
@@ -12,7 +12,7 @@ import pkg_resources as pkg
 import numpy as np
 
 from fooof import FOOOFGroup
-from fooof.tests.utils import mk_fake_group_data
+from fooof.synth import mk_fake_group_data
 
 ##########################################################################################
 ##########################################################################################

--- a/fooof/tests/test_group.py
+++ b/fooof/tests/test_group.py
@@ -75,3 +75,14 @@ def test_fooof_group_plot_get_report():
 	fg.create_report(save_name=file_name, save_path=file_path)
 
 	assert os.path.exists(os.path.join(file_path, file_name + '.pdf'))
+
+def test_fooof_group_model():
+	"""Check that running the top level model method runs."""
+
+	xs, ys = mk_fake_group_data(np.arange(3, 50, 0.5))
+
+	fg = FOOOFGroup()
+
+	fg.model(xs, ys)
+
+	assert fg

--- a/fooof/tests/test_plts.py
+++ b/fooof/tests/test_plts.py
@@ -1,0 +1,42 @@
+"""Test functions for FOOOF plots."""
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from fooof.plts import *
+
+###################################################################################################
+###################################################################################################
+
+def test_plot_scatter_1():
+
+	plt.close('all')
+
+	dat = np.random.randint(0, 100, 100)
+
+	plot_scatter_1(dat, 'label', 'title')
+
+	ax = plt.gca()
+	assert ax.has_data()
+
+def test_plot_scatter_2():
+
+	plt.close('all')
+
+	dat1 = np.random.randint(0, 100, 100)
+	dat2 = np.random.randint(0, 100, 100)
+
+	plot_scatter_2(dat1, 'label1', dat2, 'label2', 'title')
+
+	ax = plt.gca()
+	assert ax.has_data()
+
+def test_plot_hist():
+
+	plt.close('all')
+
+	dat = np.random.randint(0, 100, 100)
+	plot_hist(dat, 'label', 'title')
+
+	ax = plt.gca()
+	assert ax.has_data()

--- a/fooof/tests/test_synth.py
+++ b/fooof/tests/test_synth.py
@@ -1,0 +1,31 @@
+"""Test functions for FOOOF synth."""
+
+from fooof.utils import mk_freq_vector
+from fooof.synth import *
+
+###################################################################################################
+###################################################################################################
+
+def test_mk_fake_data():
+
+	xs = mk_freq_vector([3, 50], 0.5)
+
+	bgp = [50, 2]
+	oscs = [[10, 0.5, 2],
+			[20, 0.3, 4]]
+
+	xs, ys = mk_fake_data(xs, bgp, [it for osc in oscs for it in osc])
+
+	assert np.all(xs)
+	assert np.all(ys)
+	assert len(xs) == len(ys)
+
+def test_mk_fake_group_data():
+
+	xs = mk_freq_vector([3, 50], 0.5)
+
+	xs, ys = mk_fake_group_data(xs)
+
+	assert np.all(xs)
+	assert np.all(ys)
+	assert ys.ndim == 2

--- a/fooof/tests/test_utils.py
+++ b/fooof/tests/test_utils.py
@@ -3,25 +3,61 @@
 from py.test import raises
 import numpy as np
 
-from fooof.utils import group_three, trim_psd
+from fooof.utils import *
 
 ###################################################################################################
 ###################################################################################################
 
 def test_group_three():
 
-	dat = [0, 1, 2, 3, 4, 5]
-	assert group_three(dat) == [[0, 1, 2], [3, 4, 5]]
+    dat = [0, 1, 2, 3, 4, 5]
+    assert group_three(dat) == [[0, 1, 2], [3, 4, 5]]
 
-	with raises(ValueError):
-		group_three([0, 1, 2, 3])
+    with raises(ValueError):
+        group_three([0, 1, 2, 3])
+
+def test_dict_array_to_lst():
+
+    t_dict = {'a' : 1, 'b' : np.array([1, 2, 3]), 'c' : [4, 5, 6], 'd' : np.array([7, 8, 9])}
+
+    out = dict_array_to_lst(t_dict)
+
+    for ke, va in out.items():
+        assert not isinstance(va, np.ndarray)
+
+def test_dict_lst_to_array():
+
+    t_dict = {'a' : 1, 'b' : [1, 2, 3], 'c' : [4, 5, 6], 'd' : np.array([7, 8, 9])}
+    mk_array = ['b', 'c']
+
+    out = dict_lst_to_array(t_dict, mk_array)
+
+    for ke, va in out.items():
+        if ke in mk_array:
+            assert isinstance(va, np.ndarray)
+
+def test_dict_select_keys():
+
+    t_dict = {'a' : 1, 'b' : [1, 2, 3], 'c' : [4, 5, 6], 'd' : np.array([7, 8, 9])}
+    keep = ['a', 'd']
+
+    out = dict_select_keys(t_dict, keep)
+
+    for ke, va in out.items():
+        if ke in keep:
+            continue
+        assert False
 
 def test_trim_psd():
 
-	f_in = np.array([0., 1., 2., 3., 4., 5.])
-	p_in = np.array([1., 2., 3., 4., 5., 6.])
+    f_in = np.array([0., 1., 2., 3., 4., 5.])
+    p_in = np.array([1., 2., 3., 4., 5., 6.])
 
-	f_out, p_out = trim_psd(f_in, p_in, [2., 4.])
+    f_out, p_out = trim_psd(f_in, p_in, [2., 4.])
 
-	assert np.array_equal(f_out, np.array([2., 3., 4.]))
-	assert np.array_equal(p_out, np.array([3., 4., 5.]))
+    assert np.array_equal(f_out, np.array([2., 3., 4.]))
+    assert np.array_equal(p_out, np.array([3., 4., 5.]))
+
+def test_get_attribute_names():
+
+    assert get_attribute_names()

--- a/fooof/utils.py
+++ b/fooof/utils.py
@@ -115,6 +115,31 @@ def trim_psd(freqs, psd, f_range):
     return freqs_ext, psd_ext
 
 
+def mk_freq_vector(freq_range, freq_res):
+    """Regenerate a frequency vector, from the frequency range and resolution.
+
+    Parameters
+    ----------
+    freq_range : list of [float, float]
+        Frequency range of desired frequency vector, as [f_low, f_high].
+    freq_res : float
+        Frequency resolution of desired frequency vector.
+
+    Returns
+    -------
+    1d array
+        Vector of frequency values.
+    """
+
+    return np.arange(freq_range[0], freq_range[1]+freq_res, freq_res)
+
+
+def check_array_dim(arr):
+    """Check that parameter array has the correct shape, and reshape if not."""
+
+    return np.empty([0, 3]) if arr.ndim == 1 else arr
+
+
 def get_attribute_names():
     """Get dictionary specifying FOOOF object names and kind of attributes."""
 

--- a/summary.sh
+++ b/summary.sh
@@ -20,7 +20,7 @@ coverage report
 # Run pylint and print summary
 printf "\n\n\n RUN PYLINT ACROSS MODULE: \n"
 pylint fooof --ignore tests -> _lint.txt
-tail -n5 _lint.txt
+tail -n4 _lint.txt
 
 # Print out some new lines
 printf "\n\n\n"


### PR DESCRIPTION
FOOOF Last PR:
	Okay, so like actually though, these should be pretty much the last changes. 

Change Log:
- Clean up FOOOFGroup API, by updating so that .load() loads a group file (by aliasing FOOOF.load()), and similarly for .fit() and .save().
- Fix up Group plotting for including knee, including a re-org, increased modularization of plotting methods. This includes moving out some plot templates to a separate file.
- Move synthetic PSD generation outside of test code, so it's more accessible for general use.
- Add some test code, more explicit/modular testing of some functions/methods.
- Make FOOOFResult consistent with FOOOF object - oscillations_params -> oscillation_params
- After hemming and hawing: added _gaussian_params to FOOOFResult object. It makes some back and forth easier (my arg against was that it's now more confusing having two slightly different sets of params for oscillations, but they are each somewhat differently useful). I'm not totally convinced by this - but updated, at least for now.
- Add support for putting results back into FOOOF object (to, for example, regenerate and plot the model), rebuilding a FOOOF object from FOOOFGroup. 
- Save out FOOOFGroup results post-fitting (this is made easier & more consistent with updating FOOOFResult, and putting results back into FOOOF). 
- Remove option to 'save as you go' while running FOOOFGroup. This option wasn't clearly super useful, and somewhat complicated / messied things. Could be re-added.
- Added support for running FOOOFGroup in parallel. 

- Full py2 compatibility looks to be pretty annoying to retrofit and maintain at this point, because I didn't write a bunch of stuff with it in mind. New plan (if agreeable) is to properly release as py3 only. The core algorithm code is (I think), all Py27 compatible, so I'm going to try and make a bare-bones branch that will run on py27, but without some of the 'frills', for any who really want/need that (but strongly recommend that people use py3).