### PR TITLE
I mean it this time

### DIFF
--- a/fooof/core/io.py
+++ b/fooof/core/io.py
@@ -41,7 +41,7 @@ def save_fm(fm, file_name, file_path='', append=False,
     attributes = get_obj_desc()
     keep = set((attributes['results'] if save_results else []) + \
                (attributes['settings'] if save_settings else []) + \
-               (attributes['dat'] if save_data else []))
+               (attributes['data'] if save_data else []))
     obj_dict = dict_select_keys(obj_dict, keep)
 
     # Save out - create new file, (creates a JSON file)

--- a/fooof/core/io.py
+++ b/fooof/core/io.py
@@ -38,8 +38,9 @@ def save_fm(fm, file_name, file_path='', append=False,
     obj_dict = dict_array_to_lst(fm.__dict__)
 
     # Set and select which variables to keep. Use a set to drop any potential overlap
+    #  Note that results also saves frequency information to be able to recreate freq vector
     attributes = get_obj_desc()
-    keep = set((attributes['results'] if save_results else []) + \
+    keep = set((attributes['results'] + attributes['freq_info'] if save_results else []) + \
                (attributes['settings'] if save_settings else []) + \
                (attributes['data'] if save_data else []))
     obj_dict = dict_select_keys(obj_dict, keep)

--- a/fooof/core/modutils.py
+++ b/fooof/core/modutils.py
@@ -40,7 +40,7 @@ def get_obj_desc():
     attributes = {'results' : ['background_params_', 'peak_params_', 'error_', 'r_squared_',
                                '_gaussian_params', 'freq_range', 'freq_res'],
                   'settings' : ['peak_width_limits', 'max_n_peaks', 'min_peak_amplitude',
-                                'min_peak_threshhold', 'background_mode'],
+                                'min_peak_threshold', 'background_mode'],
                   'dat' : ['power_spectrum', 'freq_range', 'freq_res'],
                   'arrays' : ['freqs', 'power_spectrum', 'background_params_',
                               'peak_params_', '_gaussian_params']}

--- a/fooof/core/modutils.py
+++ b/fooof/core/modutils.py
@@ -40,7 +40,7 @@ def get_obj_desc():
     attributes = {'results' : ['background_params_', 'peak_params_', 'error_',
                                'r_squared_', '_gaussian_params'],
                   'settings' : ['peak_width_limits', 'max_n_peaks', 'min_peak_amplitude',
-                                'min_peak_threshold', 'background_mode'],
+                                'peak_threshold', 'background_mode'],
                   'data' : ['power_spectrum', 'freq_range', 'freq_res'],
                   'freq_info' : ['freq_range', 'freq_res'],
                   'arrays' : ['freqs', 'power_spectrum', 'background_params_',

--- a/fooof/core/modutils.py
+++ b/fooof/core/modutils.py
@@ -41,7 +41,7 @@ def get_obj_desc():
                                '_gaussian_params', 'freq_range', 'freq_res'],
                   'settings' : ['peak_width_limits', 'max_n_peaks', 'min_peak_amplitude',
                                 'min_peak_threshold', 'background_mode'],
-                  'dat' : ['power_spectrum', 'freq_range', 'freq_res'],
+                  'data' : ['power_spectrum', 'freq_range', 'freq_res'],
                   'arrays' : ['freqs', 'power_spectrum', 'background_params_',
                               'peak_params_', '_gaussian_params']}
 

--- a/fooof/core/modutils.py
+++ b/fooof/core/modutils.py
@@ -37,11 +37,12 @@ def safe_import(*args):
 def get_obj_desc():
     """Get dictionary specifying FOOOF object names and kind of attributes."""
 
-    attributes = {'results' : ['background_params_', 'peak_params_', 'error_', 'r_squared_',
-                               '_gaussian_params', 'freq_range', 'freq_res'],
+    attributes = {'results' : ['background_params_', 'peak_params_', 'error_',
+                               'r_squared_', '_gaussian_params'],
                   'settings' : ['peak_width_limits', 'max_n_peaks', 'min_peak_amplitude',
                                 'min_peak_threshold', 'background_mode'],
                   'data' : ['power_spectrum', 'freq_range', 'freq_res'],
+                  'freq_info' : ['freq_range', 'freq_res'],
                   'arrays' : ['freqs', 'power_spectrum', 'background_params_',
                               'peak_params_', '_gaussian_params']}
 

--- a/fooof/core/reports.py
+++ b/fooof/core/reports.py
@@ -32,12 +32,12 @@ def save_report_fm(fm, file_name, file_path='', plt_log=False):
 
     # Set up outline figure, using gridspec
     fig = plt.figure(figsize=(16, 20))
-    grid = gridspec.GridSpec(3, 1, height_ratios=[0.8, 1.0, 0.7])
+    grid = gridspec.GridSpec(3, 1, height_ratios=[0.45, 1.0, 0.25])
 
     # First - text results
     ax0 = plt.subplot(grid[0])
     results_str = gen_results_str_fm(fm)
-    ax0.text(0.5, 0.2, results_str, font, ha='center')
+    ax0.text(0.5, 0.7, results_str, font, ha='center', va='center')
     ax0.set_frame_on(False)
     ax0.set_xticks([])
     ax0.set_yticks([])
@@ -49,7 +49,7 @@ def save_report_fm(fm, file_name, file_path='', plt_log=False):
     # Third - FOOOF settings
     ax2 = plt.subplot(grid[2])
     settings_str = gen_settings_str(fm, False)
-    ax2.text(0.5, 0.2, settings_str, font, ha='center')
+    ax2.text(0.5, 0.1, settings_str, font, ha='center', va='center')
     ax2.set_frame_on(False)
     ax2.set_xticks([])
     ax2.set_yticks([])
@@ -77,12 +77,12 @@ def save_report_fg(fg, file_name, file_path=''):
 
     # Initialize figure
     fig = plt.figure(figsize=(16, 20))
-    gs = gridspec.GridSpec(3, 2, wspace=0.35, hspace=0.25, height_ratios=[1.5, 1.0, 1.2])
+    gs = gridspec.GridSpec(3, 2, wspace=0.35, hspace=0.25, height_ratios=[0.8, 1.0, 1.0])
 
     # First / top: text results
     ax0 = plt.subplot(gs[0, :])
     results_str = gen_results_str_fg(fg)
-    ax0.text(0.5, 0.0, results_str, font, ha='center')
+    ax0.text(0.5, 0.7, results_str, font, ha='center', va='center')
     ax0.set_frame_on(False)
     ax0.set_xticks([])
     ax0.set_yticks([])

--- a/fooof/core/strings.py
+++ b/fooof/core/strings.py
@@ -268,7 +268,7 @@ def gen_issue_str(concise=False):
         # Header
         '=',
         '',
-        'Contact / Reporting Information for FOOOF',
+        'CONTACT / REPORTING ISSUES WITH FOOOF',
         '',
 
         # Reporting bugs
@@ -277,17 +277,15 @@ def gen_issue_str(concise=False):
         '',
 
         # Reporting a weird fit
-        'If FOOOF gives you any weird / bad fits, we would like to know, so we can make it better!',
-        'To help us with this, send us a FOOOF report, and a FOOOF data file, for any bad fits.',
+        'If FOOOF gives you any weird / bad fits, please let us know!',
+        'To do so, send us a FOOOF report, and a FOOOF data file, ',
         '',
-        'With a FOOOF object (fm), after fitting, run the following commands:',
+        "With a FOOOF object (fm), after fitting, run the following commands:",
         "fm.create_report('FOOOF_bad_fit_report')",
         "fm.save('FOOOF_bad_fit_data', True, True, True)",
         '',
-        "Send the generated files ('FOOOF_bad_fit_report.pdf' & 'FOOOF_bad_fit_data.json') to us.",
+        'Send the generated files to us.',
         'We will have a look, and provide any feedback we can.',
-        '',
-        'We suggest sending individual examplars, but the above will also work with a FOOOFGroup.',
         '',
 
         # Contact

--- a/fooof/core/strings.py
+++ b/fooof/core/strings.py
@@ -61,7 +61,7 @@ def gen_settings_str(f_obj, description=False, concise=False):
             'peak_width_limits'     : 'Enforced limits for peak widths, in Hz.',
             'max_n_peaks'           : 'The maximum number of peaks that can be extracted.',
             'min_peak_amplitude'    : "Minimum absolute amplitude of a peak, above background.",
-            'min_peak_threshold'    : "Threshold at which to stop searching for peaks."}
+            'peak_threshold'    : "Threshold at which to stop searching for peaks."}
 
     # Clear description for printing if not requested
     if not description:
@@ -85,8 +85,8 @@ def gen_settings_str(f_obj, description=False, concise=False):
                         '{}'.format(desc['max_n_peaks']),
                         'Minimum Amplitude : {}'.format(f_obj.min_peak_amplitude),
                         '{}'.format(desc['min_peak_amplitude']),
-                        'Amplitude Threshold: {}'.format(f_obj.min_peak_threshold),
-                        '{}'.format(desc['min_peak_threshold'])] if el != ''],
+                        'Amplitude Threshold: {}'.format(f_obj.peak_threshold),
+                        '{}'.format(desc['peak_threshold'])] if el != ''],
 
         # Footer
         '',

--- a/fooof/fit.py
+++ b/fooof/fit.py
@@ -350,7 +350,7 @@ class FOOOF(object):
                 print('Model fitting was unsuccessful.')
 
 
-    def print_settings(self, description=False, concise=True):
+    def print_settings(self, description=False, concise=False):
         """Print out the current FOOOF settings.
 
         Parameters
@@ -358,19 +358,19 @@ class FOOOF(object):
         description : bool, optional
             Whether to print out a description with current settings. default: False
         concise : bool, optional
-            Whether to print the report in a concise mode, or not. default: True
+            Whether to print the report in a concise mode, or not. default: False
         """
 
         print(gen_settings_str(self, description, concise))
 
 
-    def print_results(self, concise=True):
+    def print_results(self, concise=False):
         """Print out FOOOF results.
 
         Parameters
         ----------
         concise : bool, optional
-            Whether to print the report in a concise mode, or not. default: True
+            Whether to print the report in a concise mode, or not. default: False
         """
 
         print(gen_results_str_fm(self, concise))

--- a/fooof/fit.py
+++ b/fooof/fit.py
@@ -139,11 +139,11 @@ class FOOOF(object):
         # Threshold for how far (units of gaus std dev) a peak has to be from edge to keep.
         self._bw_std_edge = 1.0
         # Degree of overlap  (units of gauss std dev) between gaussians for one to be dropped
-        self._gauss_overlap_thresh = 1.0
+        self._gauss_overlap_thresh = 1.5
         # Parameter bounds for center frequency when fitting gaussians - in terms of +/- std dev
         self._cf_bound = 1.5
 
-        # Set internal settings (based on inputs). Initialize data attributes.
+        # Set internal settings (based on inputs). Initialize data & results attributes.
         self._reset_internal_settings()
         self._reset_data_results()
 

--- a/fooof/fit.py
+++ b/fooof/fit.py
@@ -113,7 +113,7 @@ class FOOOF(object):
         # Double check correct scipy version is being used
         from scipy import __version__
         major, minor, _ = __version__.split('.')
-        if int(major) <= 1 and int(minor) < 19:
+        if int(major) < 1 and int(minor) < 19:
             raise ImportError('Scipy version of >= 0.19.0 required.')
 
         # Set input parameters

--- a/fooof/fit.py
+++ b/fooof/fit.py
@@ -110,6 +110,12 @@ class FOOOF(object):
                  min_peak_threshold=2.0, background_mode='fixed', verbose=True):
         """Initialize FOOOF object with run parameters."""
 
+        # Double check correct scipy version is being used
+        from scipy import __version__
+        major, minor, _ = __version__.split('.')
+        if int(major) <= 1 and int(minor) < 19:
+            raise ImportError('Scipy version of >= 0.19.0 required.')
+
         # Set input parameters
         self.background_mode = background_mode
         self.peak_width_limits = peak_width_limits

--- a/fooof/fit.py
+++ b/fooof/fit.py
@@ -69,7 +69,7 @@ class FOOOF(object):
         Maximum number of gaussians to be fit in a single spectrum. default: inf
     min_peak_amplitude : float, optional
         Minimum amplitude threshold for a peak to be modeled. default: 0
-    min_peak_threshold : float, optional
+    peak_threshold : float, optional
         Threshold for detecting peaks, units of standard deviation. default: 2.0
     background_mode : {'fixed', 'knee'}
         Which approach to take to fitting the background.
@@ -107,7 +107,7 @@ class FOOOF(object):
     """
 
     def __init__(self, peak_width_limits=[0.5, 12.0], max_n_peaks=np.inf, min_peak_amplitude=0.0,
-                 min_peak_threshold=2.0, background_mode='fixed', verbose=True):
+                 peak_threshold=2.0, background_mode='fixed', verbose=True):
         """Initialize FOOOF object with run parameters."""
 
         # Double check correct scipy version is being used
@@ -121,7 +121,7 @@ class FOOOF(object):
         self.peak_width_limits = peak_width_limits
         self.max_n_peaks = max_n_peaks
         self.min_peak_amplitude = min_peak_amplitude
-        self.min_peak_threshold = min_peak_threshold
+        self.peak_threshold = peak_threshold
         self.verbose = verbose
 
         ## SETTINGS - these are updateable by the user if required.
@@ -576,7 +576,7 @@ class FOOOF(object):
             max_amp = flat_iter[max_ind]
 
             # Stop searching for peaks peaks once drops below amplitude threshold.
-            if max_amp <= self.min_peak_threshold * np.std(flat_iter):
+            if max_amp <= self.peak_threshold * np.std(flat_iter):
                 break
 
             # Set the guess parameters for gaussian fitting - CF and amp.

--- a/fooof/group.py
+++ b/fooof/group.py
@@ -256,7 +256,7 @@ class FOOOFGroup(FOOOF):
 
         # Initialize a FOOOF object, with same settings as current FOOOFGroup
         fm = FOOOF(self.peak_width_limits, self.max_n_peaks, self.min_peak_amplitude,
-                   self.min_peak_amplitude, self.background_mode, self.verbose)
+                   self.min_peak_threshold, self.background_mode, self.verbose)
 
         # Add data for specified single power spectrum, if available
         #  The power spectrum is inverted back to linear, as it's re-logged when added to FOOOF

--- a/fooof/group.py
+++ b/fooof/group.py
@@ -269,13 +269,13 @@ class FOOOFGroup(FOOOF):
         return fm
 
 
-    def print_results(self, concise=True):
+    def print_results(self, concise=False):
         """Print out FOOOFGroup results.
 
         Parameters
         ----------
         concise : bool, optional
-            Whether to print the report in a concise mode, or not. default: True
+            Whether to print the report in a concise mode, or not. default: False
         """
 
         print(gen_results_str_fg(self, concise))

--- a/fooof/group.py
+++ b/fooof/group.py
@@ -256,7 +256,7 @@ class FOOOFGroup(FOOOF):
 
         # Initialize a FOOOF object, with same settings as current FOOOFGroup
         fm = FOOOF(self.peak_width_limits, self.max_n_peaks, self.min_peak_amplitude,
-                   self.min_peak_threshold, self.background_mode, self.verbose)
+                   self.peak_threshold, self.background_mode, self.verbose)
 
         # Add data for specified single power spectrum, if available
         #  The power spectrum is inverted back to linear, as it's re-logged when added to FOOOF

--- a/fooof/plts/fg.py
+++ b/fooof/plts/fg.py
@@ -99,4 +99,4 @@ def plot_fg_peak_cens(fg, ax=None):
     """
 
     plot_hist(fg.get_all_data('peak_params', 0), 'Center Frequency',
-              'Peaks', x_lims=fg.freq_range, ax=ax)
+              'Peaks - Center Frequencies', x_lims=fg.freq_range, ax=ax)

--- a/fooof/plts/fm.py
+++ b/fooof/plts/fm.py
@@ -73,7 +73,7 @@ def plot_peak_iter(fm):
         _, ax = plt.subplots(figsize=(12, 10))
 
         plot_spectrum(fm.freqs, flatspec, linewidth=2.0, label='Flattened Spectrum', ax=ax)
-        plot_spectrum(fm.freqs, [fm.min_peak_threshold * np.std(flatspec)]*len(fm.freqs),
+        plot_spectrum(fm.freqs, [fm.peak_threshold * np.std(flatspec)]*len(fm.freqs),
                       color='orange', linestyle='dashed', label='Relative Threshold', ax=ax)
         plot_spectrum(fm.freqs, [fm.min_peak_amplitude]*len(fm.freqs),
                       color='red', linestyle='dashed', label='Absolute Threshold', ax=ax)

--- a/fooof/plts/fm.py
+++ b/fooof/plts/fm.py
@@ -41,7 +41,7 @@ def plot_fm(fm, plt_log=False, save_fig=False, file_name='FOOOF_fit', file_path=
     # Create the plot, adding data as is available
     if np.all(fm.power_spectrum):
         plot_spectrum(fm.freqs, fm.power_spectrum, plt_log, ax,
-                      color='k', linewidth=1.0, label='Original Spectrum')
+                      color='k', linewidth=1.25, label='Original Spectrum')
     if np.all(fm.fooofed_spectrum_):
         plot_spectrum(fm.freqs, fm.fooofed_spectrum_, plt_log, ax,
                       color='r', linewidth=3.0, alpha=0.5, label='Full model fit')

--- a/fooof/plts/templates.py
+++ b/fooof/plts/templates.py
@@ -79,12 +79,14 @@ def plot_scatter_1(data, label, title=None, x_val=0, ax=None):
     ax.scatter(x_data, data, s=36, alpha=0.5)
 
     if label:
-        ax.set_ylabel(label, fontsize=12)
+        ax.set_ylabel(label, fontsize=16)
 
     if title:
-        ax.set_title(title, fontsize=16)
+        ax.set_title(title, fontsize=20)
 
-    plt.xticks([x_val], [label], fontsize=12)
+    plt.xticks([x_val], [label])
+    ax.tick_params(axis='x', labelsize=16)
+    ax.tick_params(axis='y', labelsize=10)
 
     ax.set_xlim([-0.5, 0.5])
 
@@ -122,10 +124,12 @@ def plot_scatter_2(data_0, label_0, data_1, label_1, title=None, ax=None):
     plot_scatter_1(data_1, label_1, x_val=1, ax=ax1)
 
     if title:
-        ax.set_title(title, fontsize=16)
+        ax.set_title(title, fontsize=20)
 
     ax.set_xlim([-0.5, 1.5])
-    plt.xticks([0, 1], [label_0, label_1], fontsize=12)
+
+    plt.xticks([0, 1], [label_0, label_1])
+    ax.tick_params(axis='x', labelsize=16)
 
 
 @check_dependency(plt, 'matplotlib')
@@ -153,11 +157,13 @@ def plot_hist(data, label, title=None, n_bins=20, x_lims=None, ax=None):
 
     ax.hist(data[~np.isnan(data)], n_bins, alpha=0.8)
 
-    ax.set_xlabel(label, fontsize=12)
-    ax.set_ylabel('Count', fontsize=12)
+    ax.set_xlabel(label, fontsize=16)
+    ax.set_ylabel('Count', fontsize=16)
 
     if x_lims:
         ax.set_xlim(x_lims)
 
     if title:
-        ax.set_title(title, fontsize=16)
+        ax.set_title(title, fontsize=20)
+
+    ax.tick_params(axis='both', labelsize=12)

--- a/fooof/plts/templates.py
+++ b/fooof/plts/templates.py
@@ -133,7 +133,7 @@ def plot_scatter_2(data_0, label_0, data_1, label_1, title=None, ax=None):
 
 
 @check_dependency(plt, 'matplotlib')
-def plot_hist(data, label, title=None, n_bins=20, x_lims=None, ax=None):
+def plot_hist(data, label, title=None, n_bins=25, x_lims=None, ax=None):
     """Plot a histogram with the given data.
 
     Parameters

--- a/fooof/tests/test_analysis.py
+++ b/fooof/tests/test_analysis.py
@@ -10,17 +10,28 @@ from fooof.analysis import *
 def test_get_band_peak():
 
     dat = np.array([[10, 1, 1.8], [14, 2, 4]])
+
+    # Test single result
     assert np.array_equal(get_band_peak(dat, [10, 12]), [10, 1, 1.8])
+
+    # Test no results - returns nan
     assert np.all(np.isnan(get_band_peak(dat, [4, 8])))
-    assert np.array_equal(get_band_peak(dat, [10, 14], ret_one=False), [[10, 1, 1.8], [14, 2, 4]])
+
+    # Test muliple results - return all
+    assert np.array_equal(get_band_peak(dat, [10, 15], ret_one=False), [[10, 1, 1.8], [14, 2, 4]])
+
+    # Test multiple results - return one
+    assert np.array_equal(get_band_peak(dat, [10, 15], ret_one=True), [14, 2, 4])
 
 def test_get_highest_amp_osc():
 
     dat = np.array([[10, 1, 1.8], [14, 2, 4], [12, 3, 2]])
+
     assert np.array_equal(get_highest_amp_peak(dat), [12, 3, 2])
 
 def test_empty_inputs():
 
     dat = np.empty(shape=[0, 3])
+
     assert np.all(get_band_peak(dat, [8, 12]))
     assert np.all(get_highest_amp_peak(dat))

--- a/fooof/tests/test_core_io.py
+++ b/fooof/tests/test_core_io.py
@@ -4,6 +4,7 @@ import os
 import pkg_resources as pkg
 
 from fooof import FOOOF
+from fooof.core.modutils import get_obj_desc
 
 from fooof.core.io import *
 
@@ -115,3 +116,28 @@ def test_load_jsonlines():
 
     for dat in load_jsonlines(res_file_name, file_path):
         assert dat
+
+def test_load_file_contents():
+    """Check that loaded files contain the contents they should.
+
+    Note that is this test fails, it likely stems from an issue from saving.
+    """
+
+    file_name = 'test_fooof_str_all'
+    file_path = pkg.resource_filename(__name__, 'test_files')
+
+    loaded_data = load_json(file_name, file_path)
+
+    desc = get_obj_desc()
+
+    # Check settings
+    for setting in desc['settings']:
+        assert setting in loaded_data.keys()
+
+    # Check results
+    for result in desc['results']:
+        assert result in loaded_data.keys()
+
+    # Check results
+    for datum in desc['data']:
+        assert datum in loaded_data.keys()

--- a/fooof/tests/test_core_modutils.py
+++ b/fooof/tests/test_core_modutils.py
@@ -3,6 +3,7 @@
 Note: decorators (that are in modutils) are currently not tested.
 """
 
+from fooof import FOOOF
 from fooof.core.modutils import *
 
 ###################################################################################################
@@ -18,7 +19,15 @@ def test_safe_import():
 
 def test_get_obj_desc():
 
-    assert get_obj_desc()
+    desc =  get_obj_desc()
+
+    tfm = FOOOF()
+    objs = dir(tfm)
+
+    # Test that everything in dict is a valid component of the fooof object
+    for ke, va in desc.items():
+        for it in va:
+            assert it in objs
 
 def test_docs_drop_param():
 

--- a/fooof/tests/test_core_utils.py
+++ b/fooof/tests/test_core_utils.py
@@ -42,10 +42,10 @@ def test_dict_select_keys():
 
     out = dict_select_keys(t_dict, keep)
 
+    # Check the right number of items are kept, and that they are the ones specified
+    assert len(out) == len(keep)
     for ke, va in out.items():
-        if ke in keep:
-            continue
-        assert False
+        assert ke in keep
 
 def test_check_array_dim():
 

--- a/fooof/tests/test_fit.py
+++ b/fooof/tests/test_fit.py
@@ -14,6 +14,7 @@ import pkg_resources as pkg
 from fooof import FOOOF
 from fooof.synth import gen_power_spectrum
 from fooof.core.modutils import get_obj_desc
+from fooof.core.utils import group_three
 
 from fooof.tests.utils import get_tfm, plot_test
 
@@ -29,10 +30,9 @@ def test_fooof_fit_nk():
     """Test FOOOF fit, no knee."""
 
     bgp = [50, 2]
-    oscs = [[10, 0.5, 2],
-            [20, 0.3, 4]]
+    gauss_params = [10, 0.5, 2, 20, 0.3, 4]
 
-    xs, ys = gen_power_spectrum([3, 50], bgp, [it for osc in oscs for it in osc])
+    xs, ys = gen_power_spectrum([3, 50], bgp, gauss_params)
 
     tfm = FOOOF()
     tfm.fit(xs, ys)
@@ -41,17 +41,16 @@ def test_fooof_fit_nk():
     assert np.all(np.isclose(bgp, tfm.background_params_, [0.5, 0.1]))
 
     # Check model results - gaussian parameters
-    for i, osc in enumerate(oscs):
-        assert np.all(np.isclose(osc, tfm._gaussian_params[i], [1.5, 0.25, 0.5]))
+    for ii, gauss in enumerate(group_three(gauss_params)):
+        assert np.all(np.isclose(gauss, tfm._gaussian_params[ii], [1.5, 0.25, 0.5]))
 
 def test_fooof_fit_knee():
     """Test FOOOF fit, with a knee."""
 
     bgp = [50, 2, 1]
-    oscs = [[10, 0.5, 2],
-            [20, 0.3, 4]]
+    gauss_params = [10, 0.5, 2, 20, 0.3, 4]
 
-    xs, ys = gen_power_spectrum([3, 50], bgp, [it for osc in oscs for it in osc])
+    xs, ys = gen_power_spectrum([3, 50], bgp, gauss_params)
 
     tfm = FOOOF(background_mode='knee')
     tfm.fit(xs, ys)
@@ -75,7 +74,7 @@ def test_fooof_checks():
     with raises(ValueError):
         tfm.fit(xs[:-1], ys)
 
-    # Check trim_psd range
+    # Check trim_spectrum range
     tfm.fit(xs, ys, [3, 40])
 
     # Check freq of 0 issue

--- a/fooof/tests/test_group.py
+++ b/fooof/tests/test_group.py
@@ -36,30 +36,30 @@ def test_fg_iter(tfg):
 def test_fg_fit():
     """Test FOOOFGroup fit, no knee."""
 
-    n_psds = 2
-    xs, ys = gen_group_power_spectra(n_psds, *default_group_params())
+    n_spectra = 2
+    xs, ys = gen_group_power_spectra(n_spectra, *default_group_params())
 
     tfg = FOOOFGroup()
     tfg.fit(xs, ys)
     out = tfg.get_results()
 
     assert out
-    assert len(out) == n_psds
+    assert len(out) == n_spectra
     assert isinstance(out[0], FOOOFResult)
     assert np.all(out[1].background_params)
 
 def test_fg_fit_par():
     """Test FOOOFGroup fit, running in parallel."""
 
-    n_psds = 2
-    xs, ys = gen_group_power_spectra(n_psds, *default_group_params())
+    n_spectra = 2
+    xs, ys = gen_group_power_spectra(n_spectra, *default_group_params())
 
     tfg = FOOOFGroup()
     tfg.fit(xs, ys, n_jobs=2)
     out = tfg.get_results()
 
     assert out
-    assert len(out) == n_psds
+    assert len(out) == n_spectra
     assert isinstance(out[0], FOOOFResult)
     assert np.all(out[1].background_params)
 
@@ -98,8 +98,8 @@ def test_fg_load():
 def test_fg_report(skip_if_no_mpl):
     """Check that running the top level model method runs."""
 
-    n_psds = 2
-    xs, ys = gen_group_power_spectra(n_psds, *default_group_params())
+    n_spectra = 2
+    xs, ys = gen_group_power_spectra(n_spectra, *default_group_params())
 
     tfg = FOOOFGroup()
     tfg.report(xs, ys)

--- a/fooof/tests/test_group.py
+++ b/fooof/tests/test_group.py
@@ -13,6 +13,7 @@ import numpy as np
 from fooof import FOOOFGroup
 from fooof.fit import FOOOFResult
 from fooof.synth import gen_group_power_spectra
+from fooof.core.modutils import get_obj_desc
 
 from fooof.tests.utils import default_group_params, plot_test
 
@@ -106,10 +107,20 @@ def test_fg_report(skip_if_no_mpl):
     assert tfg
 
 def test_fg_get_fooof(tfg):
-    """Check return of an individual PSD in a FOOOF object from FOOOFGroup."""
+    """Check return of an individual model fit to a FOOOF object from FOOOFGroup."""
 
+    desc = get_obj_desc()
+
+    # Check without regenerating
     tfm0 = tfg.get_fooof(0, False)
     assert tfm0
+    # Check that settings are copied over properly
+    for setting in desc['settings']:
+        assert getattr(tfg, setting) == getattr(tfm0, setting)
 
+    # Check with regenerating
     tfm1 = tfg.get_fooof(1, True)
     assert tfm1
+    # Check that regenerated model is created
+    for result in desc['results']:
+        assert np.all(getattr(tfm1, result))

--- a/fooof/tests/test_plts_templates.py
+++ b/fooof/tests/test_plts_templates.py
@@ -12,8 +12,8 @@ from fooof.tests.utils import plot_test
 def test_plot_spectrum(skip_if_no_mpl):
 
 
-    dat1 = np.random.randint(0, 100, 100)
-    dat2 = np.random.randint(0, 100, 100)
+    dat1 = np.random.randint(1, 100, 100)
+    dat2 = np.random.randint(1, 100, 100)
 
     plot_spectrum(dat1, dat2, True)
 

--- a/fooof/tests/test_synth.py
+++ b/fooof/tests/test_synth.py
@@ -23,10 +23,9 @@ def test_gen_power_spectrum():
 
     freq_range = [3, 50]
     bgp = [50, 2]
-    oscs = [[10, 0.5, 2],
-            [20, 0.3, 4]]
+    gauss_params = [10, 0.5, 2, 20, 0.3, 4]
 
-    xs, ys = gen_power_spectrum(freq_range, bgp, [it for osc in oscs for it in osc])
+    xs, ys = gen_power_spectrum(freq_range, bgp, gauss_params)
 
     assert np.all(xs)
     assert np.all(ys)
@@ -34,13 +33,13 @@ def test_gen_power_spectrum():
 
 def test_gen_group_power_spectra():
 
-    n_psds = 2
+    n_spectra = 2
 
-    xs, ys = gen_group_power_spectra(n_psds, *default_group_params())
+    xs, ys = gen_group_power_spectra(n_spectra, *default_group_params())
 
     assert np.all(xs)
     assert np.all(ys)
-    assert ys.ndim == n_psds
+    assert ys.ndim == n_spectra
 
 def test_gen_background():
 

--- a/fooof/tests/utils.py
+++ b/fooof/tests/utils.py
@@ -12,7 +12,7 @@ plt = safe_import('.pyplot', 'matplotlib')
 ###################################################################################################
 
 def get_tfm():
-    """Get a FOOOF object, with a fit PSD, for testing."""
+    """Get a FOOOF object, with a fit power spectrum, for testing."""
 
     freq_range = [3, 50]
     bg_params = [50, 2]
@@ -26,10 +26,10 @@ def get_tfm():
     return tfm
 
 def get_tfg():
-    """Get a FOOOFGroup object, with some fit PSDs, for testing."""
+    """Get a FOOOFGroup object, with some fit power spectra, for testing."""
 
-    n_psds = 2
-    xs, ys = gen_group_power_spectra(n_psds, *default_group_params())
+    n_spectra = 2
+    xs, ys = gen_group_power_spectra(n_spectra, *default_group_params())
 
     tfg = FOOOFGroup()
     tfg.fit(xs, ys)


### PR DESCRIPTION
These are minor 
These are very much actually just minor updates for v0.1.0, the last things that came up when checking back through the code, and updating tutorials. 

Changelog:
- Improve & clean up tests (in particular IO, get_obj_desc, get_fooof)
- Update gaussian overlap parameter from 1.0 -> 1.5 (units of gaussian bandwidth)
- Add explicit scipy version check 
- Clean up / update what's printed in print_report_issue
- Changes defaults for concise printing to False (this turned out to be quite annoying in the notebook - so now it's optimized for notebook, but can be shortened if desired / for terminal)
- Change name of min_peak_threshold -> peak_threshold (this is a somewhat confusing parameter to start with, and the prior name wasn't super clear and made it even more confusable with min_peak_amplitude, I think - so this is hopefully at least more differentiable). 